### PR TITLE
Only log ad segments

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ exports.handler = async (event) => {
 
       // check which segments have been FULLY downloaded
       waiters = waiters.concat(arr.segments.map(async ([firstByte, lastByte], idx) => {
-        if (range.complete(firstByte, lastByte)) {
+        if (arr.isLoggable(idx) && range.complete(firstByte, lastByte)) {
           const imp = {...bytesData, segment: idx}
           return await kinesis.putImpressionLock(redis, imp)
         } else {

--- a/lib/arrangement.js
+++ b/lib/arrangement.js
@@ -64,6 +64,11 @@ module.exports = class Arrangement {
     }
   }
 
+  // TODO: only logging "ad" segments (not original/billboard/sonicid/unknown)
+  isLoggable(idx) {
+    return this.types[idx] === 'a'
+  }
+
   encode() {
     const data = {t: this.types, b: this.bytes}
     return JSON.stringify({version: this.version, data})

--- a/lib/arrangement.test.js
+++ b/lib/arrangement.test.js
@@ -123,4 +123,16 @@ describe('arrangement', () => {
     expect(arr.bytesToPercent(3)).toEqual(0.1)
   })
 
+  it('only logs ad-type segments', () => {
+    const arr = new Arrangement(DIGEST, {version: 3, data: {t: 'aobisa?', b: [1, 2, 3, 4, 5, 6, 7, 8]}})
+    expect(arr.isLoggable(0)).toEqual(true)
+    expect(arr.isLoggable(1)).toEqual(false)
+    expect(arr.isLoggable(2)).toEqual(false)
+    expect(arr.isLoggable(3)).toEqual(false)
+    expect(arr.isLoggable(4)).toEqual(false)
+    expect(arr.isLoggable(5)).toEqual(true)
+    expect(arr.isLoggable(6)).toEqual(false)
+    expect(arr.isLoggable(99)).toEqual(false)
+  })
+
 })


### PR DESCRIPTION
For PRX/dovetail.prx.org#302.

Currently, we send a `segmentbytes` record over kinesis for _every_ segment downloaded.  This generates a lot of noise over in the [analytics-ingest-lambda](https://github.com/PRX/analytics-ingest-lambda/blob/c3f3a89249cc1407ac133472229ef2f85ccf766f/lib/inputs/byte-downloads.js#L90).  Because dovetail only includes `impressions: []` for [ad-type segments](https://github.com/PRX/dovetail.prx.org/blob/master/models/decision.js#L248).

Someday we may care to also log "non-impression" original / sonicid / billboard segments to BigQuery `dt_impressions` table.  But for now, not needed.