### PR TITLE
Final segment ranges

### DIFF
--- a/lib/arrangement.js
+++ b/lib/arrangement.js
@@ -27,11 +27,7 @@ module.exports = class Arrangement {
       throw new ArrangementInvalidError(`Mismatch ${digest}`)
     }
     this.segments = this.types.split('').map((type, idx) => {
-      if (idx === this.types.length - 1) {
-        return [this.bytes[idx], this.bytes[idx + 1]]
-      } else {
-        return [this.bytes[idx], this.bytes[idx + 1] - 1]
-      }
+      return [this.bytes[idx], this.bytes[idx + 1] - 1]
     })
   }
 

--- a/lib/arrangement.test.js
+++ b/lib/arrangement.test.js
@@ -86,7 +86,7 @@ describe('arrangement', () => {
     expect(arr.segments.length).toEqual(3)
     expect(arr.segments[0]).toEqual([10, 19])
     expect(arr.segments[1]).toEqual([20, 29])
-    expect(arr.segments[2]).toEqual([30, 40])
+    expect(arr.segments[2]).toEqual([30, 39])
   })
 
   it('calculates segment sizes', () => {
@@ -94,8 +94,8 @@ describe('arrangement', () => {
     expect(arr.segments.length).toEqual(3)
     expect(arr.segmentSize(0)).toEqual(10)
     expect(arr.segmentSize(1)).toEqual(10)
-    expect(arr.segmentSize(2)).toEqual(11)
-    expect(arr.segmentSize()).toEqual(31)
+    expect(arr.segmentSize(2)).toEqual(10)
+    expect(arr.segmentSize()).toEqual(30)
   })
 
   it('converts bytes to seconds', () => {
@@ -113,7 +113,7 @@ describe('arrangement', () => {
   })
 
   it('converts bytes to percentages', () => {
-    const arr = new Arrangement(DIGEST, {version: 3, data: {t: 'oo', b: [10, 20, 39]}})
+    const arr = new Arrangement(DIGEST, {version: 3, data: {t: 'oo', b: [10, 20, 40]}})
     expect(arr.bytesToPercent(10, 0)).toEqual(1)
     expect(arr.bytesToPercent(2, 0)).toEqual(0.2)
     expect(arr.bytesToPercent(10, 1)).toEqual(0.5)


### PR DESCRIPTION
Fixes #9.

In the dovetail arrangement json, the final number in the segment-bytes array is _exclusive_, not inclusive.