### PR TITLE
Handle info logs

### DIFF
--- a/lib/kinesis-decoder.js
+++ b/lib/kinesis-decoder.js
@@ -72,8 +72,15 @@ exports.decode = async function(str) {
     const data = JSON.parse(json)
     const messages = (data.logEvents || []).map(e => {
       const parts = e.message.split('\t')
-      const msg = JSON.parse(parts[2])
-      return {...msg, time: e.timestamp}
+
+      // format [time, guid, json] or [time, guid, level, json]
+      if (parts.length === 3) {
+        return {...JSON.parse(parts[2]), time: e.timestamp}
+      } else if (parts.length === 4) {
+        return {...JSON.parse(parts[3]), time: e.timestamp}
+      } else {
+        throw new Error(`Unrecognized message: ${e.message}`)
+      }
     })
     return messages
   } catch (err) {

--- a/lib/kinesis-decoder.test-encoder.js
+++ b/lib/kinesis-decoder.test-encoder.js
@@ -1,0 +1,60 @@
+const zlib = require('zlib')
+
+/**
+ * Encode logged events to the "cloudwatch -> kinesis" subscription event format
+ */
+exports.encodeLambdaEvent = (logEvents) => {
+  const subscription = exports.encodeSubscription(logEvents)
+  const json = JSON.stringify(subscription)
+  const encoded = zlib.gzipSync(json).toString('base64')
+  return {
+    Records: [
+      {
+        kinesis: {
+          kinesisSchemaVersion: '1.0',
+          partitionKey: 'some-string',
+          sequenceNumber: "1234567890",
+          data: encoded,
+          approximateArrivalTimestamp: 1537000000.123
+        },
+        eventSource: 'aws:kinesis',
+        eventVersion: '1.0',
+        eventID: 'shardId-000000000000:987654321',
+        eventName: 'aws:kinesis:record',
+        invokeIdentityArn: 'arn:aws:iam::1234:role/my_role',
+        awsRegion: 'us-east-1',
+        eventSourceARN: 'arn:aws:kinesis:us-east-1:1234:stream/my_stream'
+      }
+    ]
+  }
+}
+
+/**
+ * Encode log events to subscription
+ */
+exports.encodeSubscription = (logEvents) => {
+  return {
+    messageType: 'DATA_MESSAGE',
+    owner: '1234',
+    logGroup: '/aws/lambda/us-east-1.my-function-name',
+    logStream: 'log-stream-name',
+    subscriptionFilters: ['filter-name'],
+    logEvents: logEvents.map(e => exports.encodeLogEvent(e)),
+  }
+}
+
+/**
+ * Encode a log event ... should be [timestamp, message]
+ */
+exports.encodeLogEvent = ([timestamp, message]) => {
+  if (!timestamp || !message) {
+    throw new Error('Pass in log events with format [timestamp, message]')
+  }
+  const dateStr = new Date(timestamp).toISOString()
+  const random = Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15)
+  return {
+    id: 'this-doesnot-matter',
+    timestamp: timestamp,
+    message: `${dateStr}\t${random}\t${message}\n`,
+  }
+}

--- a/lib/kinesis-decoder.test.js
+++ b/lib/kinesis-decoder.test.js
@@ -1,6 +1,7 @@
 const zlib = require('zlib')
 const log = require('lambda-log')
 const decoder = require('./kinesis-decoder')
+const encoder = require('./kinesis-decoder.test-encoder')
 
 describe('kinesis-decoder', () => {
 
@@ -8,6 +9,47 @@ describe('kinesis-decoder', () => {
   const DATA = EVENT.Records[0].kinesis.data
 
   afterEach(() => jest.restoreAllMocks())
+
+  describe('test encoder', () => {
+
+    const time = 1537990270350
+    const byte = {le: '123', digest: '456', region: 'us-east-1', start: 0, end: 10, total: 100}
+
+    it('decodes some encoded json', async () => {
+      const logEvents = [[time, JSON.stringify(byte)]]
+      const encoded = encoder.encodeLambdaEvent(logEvents)
+      const results = await decoder.decodeEvent(encoded)
+      expect(results.length).toEqual(1)
+      expect(results[0]).toEqual({
+        id: `123/2018-09-26/456`,
+        le: '123',
+        digest: '456',
+        day: '2018-09-26',
+        region: 'us-east-1',
+        time: time,
+        total: 100,
+        bytes: ['0-10'],
+      })
+    })
+
+    it('handles the INFO prefix', async () => {
+      const logEvents = [[time, 'INFO\t' + JSON.stringify(byte)]]
+      const encoded = encoder.encodeLambdaEvent(logEvents)
+      const results = await decoder.decodeEvent(encoded)
+      expect(results.length).toEqual(1)
+      expect(results[0]).toEqual({
+        id: `123/2018-09-26/456`,
+        le: '123',
+        digest: '456',
+        day: '2018-09-26',
+        region: 'us-east-1',
+        time: time,
+        total: 100,
+        bytes: ['0-10'],
+      })
+    })
+
+  })
 
   it('decodes an event', async () => {
     const results = await decoder.decodeEvent(EVENT)


### PR DESCRIPTION
Handle the node10 and/or aws-linux2 log format.  Which includes an extra log-level indicator.

Node 8 looked like this:

```json
{
  "messageType": "DATA_MESSAGE",
  "owner": "561178107736",
  "logGroup": "/aws/lambda/us-east-1.infrastructure-cd-root-st-DovetailBytesLambdaFunct-KUK52LD4W99C",
  "logStream": "2019/06/14/[3]1c5f9f250e754310bc834deaf8e06f95",
  "subscriptionFilters": [
    "StackSet-dovetail-bytes-lambda-subscription-staging-843f2c66-c8ee-4bc4-86a2-69403332c141-LambdaSubscriptionFilter-1XSWXGMEBI47H"
  ],
  "logEvents": [
    {
      "id": "34800861400423140788467677179788187655721237360102146048",
      "timestamp": 1560524596403,
      "message": "2019-06-14T15:03:16.367Z\t01707eea-fc52-4dde-be8a-c4f685c6f03d\t{\"le\":\"vWCr-OU7DU-bxfxQFI7ON9C57JL76tP3PRc0ylUNWQY\",\"start\":0,\"end\":10023326,\"total\":10023327,\"digest\":\"8lCRUtJ6esMA7vO1G8sa159nyEQ_by0c2S4-Pmfkchc\",\"region\":\"us-west-2\"}\n"
    }
  ]
}
```

Node 10 looks like this:

```
{
  "messageType": "DATA_MESSAGE",
  "owner": "561178107736",
  "logGroup": "/aws/lambda/us-east-1.infrastructure-cd-root-st-DovetailBytesLambdaFunct-KUK52LD4W99C",
  "logStream": "2019/06/14/[4]b4ed1af54e6a49998b2f206d20798c53",
  "subscriptionFilters": [
    "StackSet-dovetail-bytes-lambda-subscription-staging-843f2c66-c8ee-4bc4-86a2-69403332c141-LambdaSubscriptionFilter-1XSWXGMEBI47H"
  ],
  "logEvents": [
    {
      "id": "34800844602208414033687549922238557821690375160761548800",
      "timestamp": 1560523843145,
      "message": "2019-06-14T14:50:43.145Z\t01b77ee8-2e6e-49b6-9666-4220e0d20151\tINFO\t{\"le\":\"vWCr-OU7DU-bxfxQFI7ON9C57JL76tP3PRc0ylUNWQY\",\"start\":0,\"end\":10023326,\"total\":10023327,\"digest\":\"8lCRUtJ6esMA7vO1G8sa159nyEQ_by0c2S4-Pmfkchc\",\"region\":\"us-west-2\"}\n"
    }
  ]
}
```