### PR TITLE
V4 arrangements

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -33,7 +33,7 @@ describe('handler', () => {
   })
 
   it('records whole downloads', async () => {
-    s3.__addArrangement('itest-digest', {"version":3,"data":{"t":"oaoa","b":[703,21643903,22158271,33348223,33530815]}})
+    s3.__addArrangement('itest-digest', {version:4, data: {t: 'oaoa', b: [703, 21643903, 22158271, 33348223, 33530815], a: [128, 1, 44100]}})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', time: 1, start: 0, end: 33530814})
 
     const results = await handler()
@@ -48,7 +48,7 @@ describe('handler', () => {
   })
 
   it('records empty downloads', async () => {
-    s3.__addArrangement('itest-digest', {version:3, data: {t:'aao', b: [10, 20, 30, 40]}})
+    s3.__addArrangement('itest-digest', {version: 4, data: {t: 'aao', b: [10, 20, 30, 40], a: [128, 1, 44100]}})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', time: 1, start: 0, end: 12})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', time: 1, start: 2, end: 10})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', time: 1, start: 33, end: 34})
@@ -67,10 +67,10 @@ describe('handler', () => {
   })
 
   it('uses a seconds threshold', async () => {
-    process.env.DEFAULT_BITRATE = 80 // 10 bytes per second
+    const bitrate = 0.080 // 10 bytes per second
     process.env.SECONDS_THRESHOLD = 10
 
-    s3.__addArrangement('itest-digest', {version:3, data: {t:'o', b: [100, 300]}})
+    s3.__addArrangement('itest-digest', {version: 4, data: {t: 'o', b: [100, 300], a: [bitrate, 1, 44100]}})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 0, end: 198, time: 99998})
 
     const results1 = await handler()
@@ -97,10 +97,10 @@ describe('handler', () => {
   })
 
   it('uses a percentage threshold', async () => {
-    process.env.DEFAULT_BITRATE = 800 // 100 bytes per second
+    const bitrate = 0.8 // 100 bytes per second
     process.env.PERCENT_THRESHOLD = 0.5
 
-    s3.__addArrangement('itest-digest', {version:3, data: {t:'oa', b: [100, 400, 500]}})
+    s3.__addArrangement('itest-digest', {version: 4, data: {t: 'oa', b: [100, 400, 500], a: [bitrate, 1, 44100]}})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 0, end: 248, time: 99990})
 
     const results1 = await handler()
@@ -128,8 +128,8 @@ describe('handler', () => {
   })
 
   it('does not count segments until they are fully downloaded', async () => {
-    s3.__addArrangement('itest-digest', {version:3, data: {t:'aao', b: [100, 200, 300, 4000]}})
-    s3.__addArrangement('itest-digest2', {version:3, data: {t:'aao', b: [100, 200, 300, 4000]}})
+    s3.__addArrangement('itest-digest', {version: 4, data: {t: 'aao', b: [100, 200, 300, 4000], a: [128, 1, 44100]}})
+    s3.__addArrangement('itest-digest2', {version: 4, data: {t: 'aao', b: [100, 200, 300, 4000], a: [128, 1, 44100]}})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', time: 1, start: 0, end: 198})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', time: 1, start: 200, end: 280})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', time: 1, start: 282, end: 300})
@@ -158,7 +158,7 @@ describe('handler', () => {
   })
 
   it('does not count non-ad segments', async () => {
-    s3.__addArrangement('itest-digest', {version:3, data: {t:'aobisa?', b: [1, 2, 3, 4, 5, 6, 7, 8]}})
+    s3.__addArrangement('itest-digest', {version: 4, data: {t: 'aobisa?', b: [1, 2, 3, 4, 5, 6, 7, 8], a: [128, 1, 44100]}})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', time: 1, start: 0, end: 10})
 
     const results = await handler()
@@ -174,8 +174,8 @@ describe('handler', () => {
   it('it warns on bad arrangements', async () => {
     jest.spyOn(log, 'warn').mockImplementation(() => null)
 
-    s3.__addArrangement('itest-digest', {version:3, data: {t:'o', b: [10, 100]}})
-    s3.__addArrangement('itest-digest2', {version:2, data: {t:'o', b: [10, 100]}})
+    s3.__addArrangement('itest-digest', {version: 4, data: {t: 'o', b: [10, 100], a: [128, 1, 44100]}})
+    s3.__addArrangement('itest-digest2', {version: 2, data: {t: 'o', b: [10, 100]}})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', time: 1, start: 0, end: 100})
     decoder.__addBytes({le: 'itest2', digest: 'itest-digest2', time: 1, start: 0, end: 100})
     decoder.__addBytes({le: 'itest3', digest: 'foobar', time: 1, start: 0, end: 100})
@@ -201,7 +201,7 @@ describe('handler', () => {
     const err = new RedisConnError('Something bad')
     jest.spyOn(ByteRange, 'load').mockRejectedValue(err)
     jest.spyOn(log, 'error').mockImplementation(() => null)
-    s3.__addArrangement('itest-digest', {version:3, data: {t:'o', b: [10, 100]}})
+    s3.__addArrangement('itest-digest', {version: 4, data: {t: 'o', b: [10, 100], a: [128, 2, 44100]}})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', time: 1, start: 0, end: 100})
     try {
       await handler()
@@ -210,6 +210,30 @@ describe('handler', () => {
       expect(log.error).toHaveBeenCalledTimes(1)
       expect(log.error.mock.calls[0][0].toString()).toMatch('RedisConnError: Something bad')
     }
+  })
+
+  it('uses the default bitrate and warns on v3 arrangements', async () => {
+    process.env.DEFAULT_BITRATE = 80 // 10 bytes per second
+    process.env.SECONDS_THRESHOLD = 10
+
+    s3.__addArrangement('itest-digest', {version: 3, data: {t: 'o', b: [100, 300]}})
+    decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 0, end: 198, time: 99998})
+
+    const results1 = await handler()
+    expect(results1['itest1/1970-01-01/itest-digest'].overall).toEqual(false)
+    expect(results1['itest1/1970-01-01/itest-digest'].overallBytes).toEqual(99)
+    expect(kinesis.__records.length).toEqual(1)
+    expect(kinesis.__records[0]).toEqual('itest-digest')
+
+    decoder.__clearBytes()
+    decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 199, end: 199, time: 99999})
+
+    const results2 = await handler()
+    expect(results2['itest1/1970-01-01/itest-digest'].overall).toEqual('seconds')
+    expect(results2['itest1/1970-01-01/itest-digest'].overallBytes).toEqual(100)
+    expect(kinesis.__records.length).toEqual(3)
+    expect(kinesis.__records[1]).toEqual('itest-digest')
+    expect(kinesis.__records[2]).toMatchObject({type: 'bytes'})
   })
 
 })

--- a/lib/arrangement.js
+++ b/lib/arrangement.js
@@ -16,13 +16,14 @@ module.exports = class Arrangement {
     if (!data || !data.version || !data.data) {
       throw new ArrangementInvalidError(`Invalid ${digest}`)
     }
-    if (data.version !== 3 || !data.data.b || !data.data.b.length) {
+    if (data.version < 3 || !data.data.b || !data.data.b.length) {
       kinesis.putMissingDigest(digest)
       throw new ArrangementNoBytesError(`Old ${digest}`)
     }
     this.version = data.version
     this.types = data.data.t
     this.bytes = data.data.b
+    this.analysis = (data.data.a && data.data.a.length === 3) ? data.data.a : null
     if (this.types.length !== this.bytes.length - 1) {
       throw new ArrangementInvalidError(`Mismatch ${digest}`)
     }
@@ -60,13 +61,25 @@ module.exports = class Arrangement {
     }
   }
 
+  get bitrate() {
+    if (this.analysis && this.analysis[0] > 0) {
+      if (this.analysis[0] <= 320) {
+        return this.analysis[0] * 1000
+      } else {
+        return this.analysis[0]
+      }
+    } else {
+      return (parseInt(process.env.DEFAULT_BITRATE) || DEFAULT_BITRATE)
+    }
+  }
+
   // TODO: only logging "ad" segments (not original/billboard/sonicid/unknown)
   isLoggable(idx) {
     return this.types[idx] === 'a'
   }
 
   encode() {
-    const data = {t: this.types, b: this.bytes}
+    const data = {t: this.types, b: this.bytes, a: this.analysis}
     return JSON.stringify({version: this.version, data})
   }
 
@@ -82,10 +95,8 @@ module.exports = class Arrangement {
     }
   }
 
-  // TODO: get actual bitrate from arrangement json
   bytesToSeconds(numBytes) {
-    const bitsPerSecond = (parseInt(process.env.DEFAULT_BITRATE) || DEFAULT_BITRATE)
-    return numBytes / (bitsPerSecond / 8)
+    return numBytes / (this.bitrate / 8)
   }
 
   bytesToPercent(numBytes, segmentIdx) {

--- a/lib/arrangement.js
+++ b/lib/arrangement.js
@@ -20,6 +20,9 @@ module.exports = class Arrangement {
       kinesis.putMissingDigest(digest)
       throw new ArrangementNoBytesError(`Old ${digest}`)
     }
+    if (data.version < 4 || !data.data.a || data.data.a.length !== 3) {
+      kinesis.putMissingDigest(digest) // allow, but queue for upgrade
+    }
     this.version = data.version
     this.types = data.data.t
     this.bytes = data.data.b

--- a/lib/arrangement.test.js
+++ b/lib/arrangement.test.js
@@ -14,7 +14,15 @@ describe('arrangement', () => {
   let redis, mockData
   beforeEach(() => {
     redis = new Redis()
-    mockData = {version:3,data:{f:['http://f1.mp3','http://f2.mp3','http://f3.mp3'],t:'aao',b:[123,456,789,101112]}}
+    mockData = {
+      version: 4,
+      data: {
+        f: ['http://f1.mp3', 'http://f2.mp3', 'http://f3.mp3'],
+        t: 'aao',
+        b: [123, 456, 789, 101112],
+        a: [192, 1, 44100]
+      }
+    }
     delete process.env.DEFAULT_BITRATE
   })
   afterEach(async () => {
@@ -29,9 +37,11 @@ describe('arrangement', () => {
     expect(await redis.get(KEY)).toBeNull()
 
     const arr = await Arrangement.load(DIGEST, redis)
-    expect(arr.version).toEqual(3)
+    expect(arr.version).toEqual(4)
     expect(arr.types).toEqual('aao')
     expect(arr.bytes).toEqual([123, 456, 789, 101112])
+    expect(arr.analysis).toEqual([192, 1, 44100])
+    expect(arr.bitrate).toEqual(192000)
 
     const json = await redis.get(KEY)
     expect(json).not.toBeNull()
@@ -64,6 +74,20 @@ describe('arrangement', () => {
     }
   })
 
+  it('allows loading v3 arrangements', async () => {
+    mockData.version = 3
+    delete mockData.data.a
+    s3.__addArrangement(DIGEST, mockData)
+    expect(await redis.get(KEY)).toBeNull()
+
+    const arr = await Arrangement.load(DIGEST, redis)
+    expect(arr.version).toEqual(3)
+    expect(arr.types).toEqual('aao')
+    expect(arr.bytes).toEqual([123, 456, 789, 101112])
+    expect(arr.analysis).toBeNull()
+    expect(arr.bitrate).toEqual(128000)
+  })
+
   it('throws an error for missing arrangements', async () => {
     try {
       await Arrangement.load(DIGEST, redis)
@@ -78,7 +102,22 @@ describe('arrangement', () => {
   it('loads directly from redis', async () => {
     await redis.set(KEY, JSON.stringify(mockData))
     const arr = await Arrangement.load(DIGEST, redis)
-    expect(arr.version).toEqual(3)
+    expect(arr.version).toEqual(4)
+  })
+
+  it('calculates bitrates', () => {
+    let arr = new Arrangement(DIGEST, {version: 3, data: {t: 'o', b: [1, 2]}})
+    expect(arr.bitrate).toEqual(128000)
+
+    process.env.DEFAULT_BITRATE = '129000'
+    arr = new Arrangement(DIGEST, {version: 3, data: {t: 'o', b: [1, 2]}})
+    expect(arr.bitrate).toEqual(129000)
+
+    arr = new Arrangement(DIGEST, {version: 3, data: {t: 'o', b: [1, 2], a: [130, 1, 44100]}})
+    expect(arr.bitrate).toEqual(130000)
+
+    arr = new Arrangement(DIGEST, {version: 3, data: {t: 'o', b: [1, 2], a: [131000, 1, 44100]}})
+    expect(arr.bitrate).toEqual(131000)
   })
 
   it('calculates segment ranges', () => {

--- a/lib/arrangement.test.js
+++ b/lib/arrangement.test.js
@@ -43,6 +43,8 @@ describe('arrangement', () => {
     expect(arr.analysis).toEqual([192, 1, 44100])
     expect(arr.bitrate).toEqual(192000)
 
+    expect(kinesis.__records).toEqual([])
+
     const json = await redis.get(KEY)
     expect(json).not.toBeNull()
     expect(json).toEqual(arr.encode())
@@ -74,7 +76,7 @@ describe('arrangement', () => {
     }
   })
 
-  it('allows loading v3 arrangements', async () => {
+  it('loads and upgrades v3 arrangements', async () => {
     mockData.version = 3
     delete mockData.data.a
     s3.__addArrangement(DIGEST, mockData)
@@ -86,6 +88,8 @@ describe('arrangement', () => {
     expect(arr.bytes).toEqual([123, 456, 789, 101112])
     expect(arr.analysis).toBeNull()
     expect(arr.bitrate).toEqual(128000)
+
+    expect(kinesis.__records).toEqual([DIGEST])
   })
 
   it('throws an error for missing arrangements', async () => {

--- a/lib/redis.test.js
+++ b/lib/redis.test.js
@@ -28,7 +28,7 @@ describe('redis', () => {
   })
 
   it('throws connection errors', async () => {
-    process.env.REDIS_URL = 'redis://does-not-exist'
+    process.env.REDIS_URL = 'redis://foo.bar.biz.gov'
     jest.spyOn(log, 'error').mockImplementation(() => null)
     try {
       const r2 = new Redis(0)


### PR DESCRIPTION
For #12.

Use the audio-analysis stored in v4 arrangements to determine how many seconds of audio were downloaded.  This should be merged before PRX/dovetail-stitch-lambda#38, which provides the v4 arrangements.