### PR TITLE
Require 100% of short files

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const Redis = require('./lib/redis')
 const Arrangement = require('./lib/arrangement')
 
 const DEFAULT_SECONDS_THRESHOLD = 60
-const DEFAULT_PERCENT_THRESHOLD = 0.5
+const DEFAULT_PERCENT_THRESHOLD = 0.99
 
 /**
  * Process kinesis'd cloudwatch logged bytes-download. Send to BigQuery


### PR DESCRIPTION
For #13.  Moves the default download threshold from 0.5 to 0.99.  I didn't change it to 1.0 because I'm paranoid of off-by-one errors.