### PR TITLE
Kinesis batching

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -53,11 +53,7 @@ describe('handler', () => {
     s3.__addArrangement('itest-digest', {version:4, data: {t: 'oaoa', b: [703, 21643903, 22158271, 33348223, 33530815], a: [128, 1, 44100]}})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', time: 1, start: 0, end: 33530814})
 
-    const results = await handler()
-    expect(Object.keys(results)).toEqual(['itest1/1970-01-01/itest-digest'])
-    expect(results['itest1/1970-01-01/itest-digest'].segments).toEqual([false, true, false, true])
-    expect(results['itest1/1970-01-01/itest-digest'].overall).toEqual('seconds')
-    expect(results['itest1/1970-01-01/itest-digest'].overallBytes).toEqual(33530815 - 703)
+    expect(await handler()).toEqual(3)
     expect(kinesis.__records.length).toEqual(3)
     expect(kinesis.__records[0]).toMatchObject({type: 'bytes'})
     expect(kinesis.__records[1]).toMatchObject({type: 'segmentbytes', segment: 1})
@@ -72,14 +68,7 @@ describe('handler', () => {
     decoder.__addBytes({le: 'itest2', digest: 'itest-digest', time: 1, start: 22, end: 25})
     decoder.__addBytes({le: 'itest2', digest: 'itest-digest', time: 1, start: 0, end: 4})
 
-    const results = await handler()
-    expect(Object.keys(results)).toEqual(['itest1/1970-01-01/itest-digest', 'itest2/1970-01-01/itest-digest'])
-    expect(results['itest1/1970-01-01/itest-digest'].segments).toEqual([false, false, false])
-    expect(results['itest1/1970-01-01/itest-digest'].overall).toEqual(false)
-    expect(results['itest1/1970-01-01/itest-digest'].overallBytes).toEqual(5)
-    expect(results['itest2/1970-01-01/itest-digest'].segments).toEqual([false, false, false])
-    expect(results['itest2/1970-01-01/itest-digest'].overall).toEqual(false)
-    expect(results['itest2/1970-01-01/itest-digest'].overallBytes).toEqual(4)
+    expect(await handler()).toEqual(0)
     expect(kinesis.__records.length).toEqual(0)
   })
 
@@ -90,17 +79,13 @@ describe('handler', () => {
     s3.__addArrangement('itest-digest', {version: 4, data: {t: 'o', b: [100, 300], a: [bitrate, 1, 44100]}})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 0, end: 198, time: 99998})
 
-    const results1 = await handler()
-    expect(results1['itest1/1970-01-01/itest-digest'].overall).toEqual(false)
-    expect(results1['itest1/1970-01-01/itest-digest'].overallBytes).toEqual(99)
+    expect(await handler()).toEqual(0)
     expect(kinesis.__records.length).toEqual(0)
 
     decoder.__clearBytes()
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 199, end: 199, time: 99999})
 
-    const results2 = await handler()
-    expect(results2['itest1/1970-01-01/itest-digest'].overall).toEqual('seconds')
-    expect(results2['itest1/1970-01-01/itest-digest'].overallBytes).toEqual(100)
+    expect(await handler()).toEqual(1)
     expect(kinesis.__records.length).toEqual(1)
     expect(kinesis.__records[0]).toEqual({
       type: 'bytes',
@@ -120,18 +105,14 @@ describe('handler', () => {
     s3.__addArrangement('itest-digest', {version: 4, data: {t: 'oa', b: [100, 400, 500], a: [bitrate, 1, 44100]}})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 0, end: 248, time: 99990})
 
-    const results1 = await handler()
-    expect(results1['itest1/1970-01-01/itest-digest'].overall).toEqual(false)
-    expect(results1['itest1/1970-01-01/itest-digest'].overallBytes).toEqual(149)
+    expect(await handler()).toEqual(0)
     expect(kinesis.__records.length).toEqual(0)
 
     decoder.__clearBytes()
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 399, end: 411, time: 99994})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 100, end: 397, time: 99991})
 
-    const results2 = await handler()
-    expect(results2['itest1/1970-01-01/itest-digest'].overall).toEqual('percent')
-    expect(results2['itest1/1970-01-01/itest-digest'].overallBytes).toEqual(311)
+    expect(await handler()).toEqual(1)
     expect(kinesis.__records.length).toEqual(1)
     expect(kinesis.__records[0]).toEqual({
       type: 'bytes',
@@ -148,17 +129,13 @@ describe('handler', () => {
     s3.__addArrangement('itest-digest', {version: 4, data: {t: 'o', b: [10, 20], a: [128, 1, 44100]}})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 11, end: 19, time: 99999})
 
-    const results1 = await handler()
-    expect(results1['itest1/1970-01-01/itest-digest'].overall).toEqual(false)
-    expect(results1['itest1/1970-01-01/itest-digest'].overallBytes).toEqual(9)
+    expect(await handler()).toEqual(0)
     expect(kinesis.__records.length).toEqual(0)
 
     decoder.__clearBytes()
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 10, end: 10, time: 99999})
 
-    const results2 = await handler()
-    expect(results2['itest1/1970-01-01/itest-digest'].overall).toEqual('percent')
-    expect(results2['itest1/1970-01-01/itest-digest'].overallBytes).toEqual(10)
+    expect(await handler()).toEqual(1)
     expect(kinesis.__records.length).toEqual(1)
     expect(kinesis.__records[0]).toMatchObject({type: 'bytes'})
   })
@@ -170,8 +147,7 @@ describe('handler', () => {
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', time: 1, start: 200, end: 280})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', time: 1, start: 282, end: 300})
 
-    const results1 = await handler()
-    expect(results1['itest1/1970-01-01/itest-digest'].segments).toEqual([false, false, false])
+    expect(await handler()).toEqual(0)
     expect(kinesis.__records.length).toEqual(0)
 
     decoder.__clearBytes()
@@ -179,10 +155,7 @@ describe('handler', () => {
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest2', time: 1, start: 199, end: 199})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', time: 1, start: 281, end: 281})
 
-    const results2 = await handler()
-    expect(results2['itest1/1970-01-01/itest-digest'].segments).toEqual([false, true, false])
-    expect(results2['itest1/1970-01-01/itest-digest2'].segments).toEqual([false, false, false])
-    expect(results2['itest2/1970-01-01/itest-digest'].segments).toEqual([false, false, false])
+    expect(await handler()).toEqual(1)
     expect(kinesis.__records.length).toEqual(1)
     expect(kinesis.__records[0]).toEqual({
       type: 'segmentbytes',
@@ -197,10 +170,7 @@ describe('handler', () => {
     s3.__addArrangement('itest-digest', {version: 4, data: {t: 'aobisa?', b: [1, 2, 3, 4, 5, 6, 7, 8], a: [128, 1, 44100]}})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', time: 1, start: 0, end: 10})
 
-    const results = await handler()
-    expect(results['itest1/1970-01-01/itest-digest'].overall).toEqual('percent')
-    expect(results['itest1/1970-01-01/itest-digest'].overallBytes).toEqual(7)
-    expect(results['itest1/1970-01-01/itest-digest'].segments).toEqual([true, false, false, false, false, true, false])
+    expect(await handler()).toEqual(3)
     expect(kinesis.__records.length).toEqual(3)
     expect(kinesis.__records[0]).toMatchObject({type: 'bytes'})
     expect(kinesis.__records[1]).toMatchObject({type: 'segmentbytes', segment: 0})
@@ -216,8 +186,9 @@ describe('handler', () => {
     decoder.__addBytes({le: 'itest2', digest: 'itest-digest2', time: 1, start: 0, end: 100})
     decoder.__addBytes({le: 'itest3', digest: 'foobar', time: 1, start: 0, end: 100})
 
-    const results = await handler()
-    expect(results['itest1/1970-01-01/itest-digest'].overallBytes).toEqual(90)
+    expect(await handler()).toEqual(1)
+    expect(kinesis.__records.length).toEqual(1)
+    expect(kinesis.__records[0]).toMatchObject({type: 'bytes', listenerEpisode: 'itest1'})
     expect(log.warn).toHaveBeenCalledTimes(2)
     const warns = log.warn.mock.calls.map(c => c[0].toString()).sort()
     expect(warns[0]).toMatch('ArrangementNoBytesError: Old itest-digest2')
@@ -255,21 +226,21 @@ describe('handler', () => {
     s3.__addArrangement('itest-digest', {version: 3, data: {t: 'o', b: [100, 300]}})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 0, end: 198, time: 99998})
 
-    const results1 = await handler()
-    expect(results1['itest1/1970-01-01/itest-digest'].overall).toEqual(false)
-    expect(results1['itest1/1970-01-01/itest-digest'].overallBytes).toEqual(99)
-    expect(kinesis.__records.length).toEqual(1)
-    expect(kinesis.__records[0]).toEqual('itest-digest')
+    jest.spyOn(log, 'warn').mockImplementation()
+    expect(await handler()).toEqual(0)
+    expect(log.warn).toHaveBeenCalledTimes(1)
+    expect(log.warn.mock.calls[0][0]).toEqual('Non v4 arrangement')
+    expect(log.warn.mock.calls[0][1]).toEqual({digest: 'itest-digest'})
 
     decoder.__clearBytes()
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 199, end: 199, time: 99999})
 
-    const results2 = await handler()
-    expect(results2['itest1/1970-01-01/itest-digest'].overall).toEqual('seconds')
-    expect(results2['itest1/1970-01-01/itest-digest'].overallBytes).toEqual(100)
-    expect(kinesis.__records.length).toEqual(3)
-    expect(kinesis.__records[1]).toEqual('itest-digest')
-    expect(kinesis.__records[2]).toMatchObject({type: 'bytes'})
+    expect(await handler()).toEqual(1)
+    expect(kinesis.__records.length).toEqual(1)
+    expect(kinesis.__records[0]).toMatchObject({type: 'bytes'})
+    expect(log.warn).toHaveBeenCalledTimes(2)
+    expect(log.warn.mock.calls[1][0]).toEqual('Non v4 arrangement')
+    expect(log.warn.mock.calls[1][1]).toEqual({digest: 'itest-digest'})
   })
 
 })

--- a/index.test.js
+++ b/index.test.js
@@ -53,7 +53,7 @@ describe('handler', () => {
     s3.__addArrangement('itest-digest', {version:4, data: {t: 'oaoa', b: [703, 21643903, 22158271, 33348223, 33530815], a: [128, 1, 44100]}})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', time: 1, start: 0, end: 33530814})
 
-    expect(await handler()).toEqual(3)
+    expect(await handler()).toMatchObject({overall: 1, segments: 2})
     expect(kinesis.__records.length).toEqual(3)
     expect(kinesis.__records[0]).toMatchObject({type: 'bytes'})
     expect(kinesis.__records[1]).toMatchObject({type: 'segmentbytes', segment: 1})
@@ -68,7 +68,7 @@ describe('handler', () => {
     decoder.__addBytes({le: 'itest2', digest: 'itest-digest', time: 1, start: 22, end: 25})
     decoder.__addBytes({le: 'itest2', digest: 'itest-digest', time: 1, start: 0, end: 4})
 
-    expect(await handler()).toEqual(0)
+    expect(await handler()).toMatchObject({overall: 0, segments: 0})
     expect(kinesis.__records.length).toEqual(0)
   })
 
@@ -79,13 +79,13 @@ describe('handler', () => {
     s3.__addArrangement('itest-digest', {version: 4, data: {t: 'o', b: [100, 300], a: [bitrate, 1, 44100]}})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 0, end: 198, time: 99998})
 
-    expect(await handler()).toEqual(0)
+    expect(await handler()).toMatchObject({overall: 0})
     expect(kinesis.__records.length).toEqual(0)
 
     decoder.__clearBytes()
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 199, end: 199, time: 99999})
 
-    expect(await handler()).toEqual(1)
+    expect(await handler()).toMatchObject({overall: 1})
     expect(kinesis.__records.length).toEqual(1)
     expect(kinesis.__records[0]).toEqual({
       type: 'bytes',
@@ -105,14 +105,14 @@ describe('handler', () => {
     s3.__addArrangement('itest-digest', {version: 4, data: {t: 'oa', b: [100, 400, 500], a: [bitrate, 1, 44100]}})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 0, end: 248, time: 99990})
 
-    expect(await handler()).toEqual(0)
+    expect(await handler()).toMatchObject({overall: 0})
     expect(kinesis.__records.length).toEqual(0)
 
     decoder.__clearBytes()
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 399, end: 411, time: 99994})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 100, end: 397, time: 99991})
 
-    expect(await handler()).toEqual(1)
+    expect(await handler()).toMatchObject({overall: 1})
     expect(kinesis.__records.length).toEqual(1)
     expect(kinesis.__records[0]).toEqual({
       type: 'bytes',
@@ -129,13 +129,13 @@ describe('handler', () => {
     s3.__addArrangement('itest-digest', {version: 4, data: {t: 'o', b: [10, 20], a: [128, 1, 44100]}})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 11, end: 19, time: 99999})
 
-    expect(await handler()).toEqual(0)
+    expect(await handler()).toMatchObject({overall: 0})
     expect(kinesis.__records.length).toEqual(0)
 
     decoder.__clearBytes()
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 10, end: 10, time: 99999})
 
-    expect(await handler()).toEqual(1)
+    expect(await handler()).toMatchObject({overall: 1})
     expect(kinesis.__records.length).toEqual(1)
     expect(kinesis.__records[0]).toMatchObject({type: 'bytes'})
   })
@@ -147,7 +147,7 @@ describe('handler', () => {
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', time: 1, start: 200, end: 280})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', time: 1, start: 282, end: 300})
 
-    expect(await handler()).toEqual(0)
+    expect(await handler()).toMatchObject({overall: 0, segments: 0})
     expect(kinesis.__records.length).toEqual(0)
 
     decoder.__clearBytes()
@@ -155,7 +155,7 @@ describe('handler', () => {
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest2', time: 1, start: 199, end: 199})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', time: 1, start: 281, end: 281})
 
-    expect(await handler()).toEqual(1)
+    expect(await handler()).toMatchObject({overall: 0, segments: 1})
     expect(kinesis.__records.length).toEqual(1)
     expect(kinesis.__records[0]).toEqual({
       type: 'segmentbytes',
@@ -170,7 +170,7 @@ describe('handler', () => {
     s3.__addArrangement('itest-digest', {version: 4, data: {t: 'aobisa?', b: [1, 2, 3, 4, 5, 6, 7, 8], a: [128, 1, 44100]}})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', time: 1, start: 0, end: 10})
 
-    expect(await handler()).toEqual(3)
+    expect(await handler()).toMatchObject({overall: 1, segments: 2})
     expect(kinesis.__records.length).toEqual(3)
     expect(kinesis.__records[0]).toMatchObject({type: 'bytes'})
     expect(kinesis.__records[1]).toMatchObject({type: 'segmentbytes', segment: 0})
@@ -186,7 +186,7 @@ describe('handler', () => {
     decoder.__addBytes({le: 'itest2', digest: 'itest-digest2', time: 1, start: 0, end: 100})
     decoder.__addBytes({le: 'itest3', digest: 'foobar', time: 1, start: 0, end: 100})
 
-    expect(await handler()).toEqual(1)
+    expect(await handler()).toMatchObject({overall: 1, segments: 0})
     expect(kinesis.__records.length).toEqual(1)
     expect(kinesis.__records[0]).toMatchObject({type: 'bytes', listenerEpisode: 'itest1'})
     expect(log.warn).toHaveBeenCalledTimes(2)
@@ -199,7 +199,7 @@ describe('handler', () => {
     const err = new BadEventError('Something bad')
     jest.spyOn(decoder, 'decodeEvent').mockRejectedValue(err)
     jest.spyOn(log, 'error').mockImplementation(() => null)
-    expect(await handler()).toEqual(false)
+    expect(await handler()).toEqual(null)
     expect(log.error).toHaveBeenCalledTimes(1)
     expect(log.error.mock.calls[0][0].toString()).toMatch('BadEventError: Something bad')
   })
@@ -227,7 +227,7 @@ describe('handler', () => {
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 0, end: 198, time: 99998})
 
     jest.spyOn(log, 'warn').mockImplementation()
-    expect(await handler()).toEqual(0)
+    expect(await handler()).toMatchObject({overall: 0, segments: 0})
     expect(log.warn).toHaveBeenCalledTimes(1)
     expect(log.warn.mock.calls[0][0]).toEqual('Non v4 arrangement')
     expect(log.warn.mock.calls[0][1]).toEqual({digest: 'itest-digest'})
@@ -235,12 +235,29 @@ describe('handler', () => {
     decoder.__clearBytes()
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 199, end: 199, time: 99999})
 
-    expect(await handler()).toEqual(1)
+    expect(await handler()).toMatchObject({overall: 1, segments: 0})
     expect(kinesis.__records.length).toEqual(1)
     expect(kinesis.__records[0]).toMatchObject({type: 'bytes'})
     expect(log.warn).toHaveBeenCalledTimes(2)
     expect(log.warn.mock.calls[1][0]).toEqual('Non v4 arrangement')
     expect(log.warn.mock.calls[1][1]).toEqual({digest: 'itest-digest'})
+  })
+
+  it('throws a retryable error on kinesis put failure', async () => {
+    jest.spyOn(kinesis, 'putWithLock').mockImplementation(async () => {
+      return {failed: 1}
+    })
+    jest.spyOn(log, 'error').mockImplementation(() => null)
+
+    s3.__addArrangement('itest-digest', {version: 4, data: {t: 'o', b: [10, 20], a: [128, 1, 44100]}})
+    decoder.__addBytes({le: 'itest1', digest: 'itest-digest', start: 0, end: 19, time: 99999})
+    try {
+      await handler()
+      fail('should have gotten an error')
+    } catch (err) {
+      expect(log.error).toHaveBeenCalledTimes(1)
+      expect(log.error.mock.calls[0][0].toString()).toMatch('Failed to put 1')
+    }
   })
 
 })

--- a/lib/__mocks__/kinesis.js
+++ b/lib/__mocks__/kinesis.js
@@ -1,18 +1,19 @@
 const kinesis = jest.genMockFromModule('../kinesis')
+const actual = require.requireActual('../kinesis')
 
-process.env.KINESIS_ARRANGEMENT_STREAM = 'anything'
 process.env.KINESIS_IMPRESSION_STREAM = 'anything'
 
 kinesis.__records = []
 kinesis.__clearRecords = () => kinesis.__records = []
-kinesis.putRecord = require.requireActual('../kinesis').putRecord = async (stream, data) => {
-  kinesis.__records.push(data)
-  return true
+
+// use a fake _putRecords
+actual._putRecords = async ({StreamName, Records}) => {
+  Records.forEach(({Data}) => kinesis.__records.push(JSON.parse(Data)))
+  return {Records: Records.map(r => ({}))}
 }
 
 // call actual put methods
-kinesis.putMissingDigest = require.requireActual('../kinesis').putMissingDigest
-kinesis.putImpression = require.requireActual('../kinesis').putImpression
-kinesis.putImpressionLock = require.requireActual('../kinesis').putImpressionLock
+kinesis.format = actual.format
+kinesis.putWithLock = actual.putWithLock
 
 module.exports = kinesis

--- a/lib/arrangement.js
+++ b/lib/arrangement.js
@@ -1,6 +1,6 @@
+const log = require('lambda-log')
 const { ArrangementNotFoundError, ArrangementInvalidError, ArrangementNoBytesError } = require('./errors')
 const s3 = require('./s3')
-const kinesis = require('./kinesis')
 
 const DEFAULT_TTL = 86400
 const DEFAULT_BITRATE = 128000
@@ -17,11 +17,10 @@ module.exports = class Arrangement {
       throw new ArrangementInvalidError(`Invalid ${digest}`)
     }
     if (data.version < 3 || !data.data.b || !data.data.b.length) {
-      kinesis.putMissingDigest(digest)
       throw new ArrangementNoBytesError(`Old ${digest}`)
     }
     if (data.version < 4 || !data.data.a || data.data.a.length !== 3) {
-      kinesis.putMissingDigest(digest) // allow, but queue for upgrade
+      log.warn('Non v4 arrangement', {digest}) // allow, but warn
     }
     this.version = data.version
     this.types = data.data.t
@@ -58,7 +57,6 @@ module.exports = class Arrangement {
         await redis.setex(`dtcounts:s3:${digest}`, ttl, arr.encode())
         return arr
       } else {
-        kinesis.putMissingDigest(digest)
         throw new ArrangementNotFoundError(`Missing ${digest}`)
       }
     }

--- a/lib/arrangement.test.js
+++ b/lib/arrangement.test.js
@@ -1,17 +1,16 @@
+const log = require('lambda-log')
 const Arrangement = require('./arrangement')
 const RedisBackup = require('./redis-backup')
 const s3 = require('./s3')
-const kinesis = require('./kinesis')
 
 jest.mock('./s3')
-jest.mock('./kinesis')
 
 describe('arrangement', () => {
 
   const DIGEST = 'arrangement.test'
   const KEY = `dtcounts:s3:${DIGEST}`
 
-  let redis, mockData
+  let redis, mockData, warns
   beforeEach(() => {
     redis = new RedisBackup(process.env.REDIS_URL)
     mockData = {
@@ -23,13 +22,15 @@ describe('arrangement', () => {
         a: [192, 1, 44100]
       }
     }
+    warns = []
+    jest.spyOn(log, 'warn').mockImplementation((...args) => warns.push(args))
     delete process.env.DEFAULT_BITRATE
   })
   afterEach(async () => {
     s3.__clearArrangements()
-    kinesis.__clearRecords()
     await redis.del(KEY)
     await redis.disconnect()
+    jest.restoreAllMocks()
   })
 
   it('gets json from s3 and uploads to redis', async () => {
@@ -42,8 +43,6 @@ describe('arrangement', () => {
     expect(arr.bytes).toEqual([123, 456, 789, 101112])
     expect(arr.analysis).toEqual([192, 1, 44100])
     expect(arr.bitrate).toEqual(192000)
-
-    expect(kinesis.__records).toEqual([])
 
     const json = await redis.get(KEY)
     expect(json).not.toBeNull()
@@ -72,7 +71,6 @@ describe('arrangement', () => {
     } catch (err) {
       expect(err.name).toEqual('ArrangementNoBytesError')
       expect(err.message).toEqual(`Old ${DIGEST}`)
-      expect(kinesis.__records).toEqual([DIGEST])
     }
   })
 
@@ -89,7 +87,9 @@ describe('arrangement', () => {
     expect(arr.analysis).toBeNull()
     expect(arr.bitrate).toEqual(128000)
 
-    expect(kinesis.__records).toEqual([DIGEST])
+    expect(warns.length).toEqual(1)
+    expect(warns[0][0]).toEqual('Non v4 arrangement')
+    expect(warns[0][1]).toEqual({digest: DIGEST})
   })
 
   it('throws an error for missing arrangements', async () => {
@@ -99,7 +99,6 @@ describe('arrangement', () => {
     } catch (err) {
       expect(err.name).toEqual('ArrangementNotFoundError')
       expect(err.message).toEqual(`Missing ${DIGEST}`)
-      expect(kinesis.__records).toEqual([DIGEST])
     }
   })
 
@@ -112,16 +111,20 @@ describe('arrangement', () => {
   it('calculates bitrates', () => {
     let arr = new Arrangement(DIGEST, {version: 3, data: {t: 'o', b: [1, 2]}})
     expect(arr.bitrate).toEqual(128000)
+    expect(warns.length).toEqual(1)
 
     process.env.DEFAULT_BITRATE = '129000'
     arr = new Arrangement(DIGEST, {version: 3, data: {t: 'o', b: [1, 2]}})
     expect(arr.bitrate).toEqual(129000)
+    expect(warns.length).toEqual(2)
 
-    arr = new Arrangement(DIGEST, {version: 3, data: {t: 'o', b: [1, 2], a: [130, 1, 44100]}})
+    arr = new Arrangement(DIGEST, {version: 4, data: {t: 'o', b: [1, 2], a: [130, 1, 44100]}})
     expect(arr.bitrate).toEqual(130000)
+    expect(warns.length).toEqual(2)
 
-    arr = new Arrangement(DIGEST, {version: 3, data: {t: 'o', b: [1, 2], a: [131000, 1, 44100]}})
+    arr = new Arrangement(DIGEST, {version: 4, data: {t: 'o', b: [1, 2], a: [131000, 1, 44100]}})
     expect(arr.bitrate).toEqual(131000)
+    expect(warns.length).toEqual(2)
   })
 
   it('calculates segment ranges', () => {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -48,6 +48,6 @@ exports.ArrangementInvalidError = class ArrangementInvalidError extends Skippabl
 exports.ArrangementNoBytesError = class ArrangementNoBytesError extends SkippableError {}
 exports.ArrangementNotFoundError = class ArrangementNotFoundError extends SkippableError {}
 exports.BadEventError = class BadEventError extends ExtendableError {}
-exports.KinesisPutError = class KinesisPutError extends ExtendableError {}
+exports.KinesisPutError = class KinesisPutError extends RetryableError {}
 exports.MissingEnvError = class MissingEnvError extends RetryableError {}
 exports.RedisConnError = class RedisConnError extends RetryableError {}

--- a/lib/kinesis-lock.js
+++ b/lib/kinesis-lock.js
@@ -1,0 +1,63 @@
+const log = require('lambda-log')
+const DEFAULT_TTL = 86400
+
+/**
+ * Lock an impression (or "all") in redis
+ */
+exports.lock = async function(redis, {segment, ...record}) {
+  const key = lockKey(record)
+  const fld = segment === undefined ? 'all' : segment
+  if (await redis.lock(key, fld, ttl())) {
+    return segment ? {segment, ...record} : {...record}
+  } else {
+    return null;
+  }
+}
+
+/**
+ * Unlock an impression (or "all") in redis w/NO ERRORS
+ */
+exports.unlock = async function(redis, {segment, ...record}) {
+  const key = lockKey(record)
+  const fld = segment === undefined ? 'all' : segment
+  try {
+    await redis.unlock(key, fld)
+    return true
+  } catch (err) {
+    log.warn(err, {key, fld, msg: 'Kinesis unlock failed'})
+    return false
+  }
+}
+
+/**
+ * Lock a listener-episode to a digest
+ */
+exports.lockDigest = async function(redis, {digest, ...record}) {
+  if (await redis.lockValue(digestKey(record), digest, ttl())) {
+    return {digest, ...record}
+  } else {
+    return {digest, isDuplicate: true, cause: 'digestCache', ...record}
+  }
+}
+
+// key for a lock
+function lockKey({timestamp, listenerEpisode, digest}) {
+  const day = timeToDay(timestamp)
+  return `dtcounts:imp:${listenerEpisode}:${day}:${digest}`
+}
+
+// key for a digest lock
+function digestKey({timestamp, listenerEpisode}) {
+  const day = timeToDay(timestamp)
+  return `dtcounts:imp:${listenerEpisode}:${day}:digest`
+}
+
+// get the UTC day for an epoch time
+function timeToDay(time) {
+  return (time ? new Date(time) : new Date).toISOString().substr(0, 10)
+}
+
+// env configured redis ttl
+function ttl() {
+  return process.env.REDIS_IMPRESSION_TTL || DEFAULT_TTL
+}

--- a/lib/kinesis-lock.js
+++ b/lib/kinesis-lock.js
@@ -38,6 +38,19 @@ exports.unlock = async function(redis, record) {
 }
 
 /**
+ * Helper to check if locked (mostly for testing)
+ */
+exports.isLocked = async function(redis, record) {
+  const key = lockKey(record)
+  const fld = record.segment === undefined ? 'all' : record.segment
+  if ((await redis.cmd('hget', key, fld)) !== null) {
+    return true
+  } else {
+    return false
+  }
+}
+
+/**
  * Lock a listener-episode to a digest
  */
 exports.lockDigest = async function(redis, record) {

--- a/lib/kinesis-lock.js
+++ b/lib/kinesis-lock.js
@@ -4,11 +4,15 @@ const DEFAULT_TTL = 86400
 /**
  * Lock an impression (or "all") in redis
  */
-exports.lock = async function(redis, {segment, ...record}) {
+exports.lock = async function(redis, record) {
+  if (!record) {
+    return null;
+  }
+
   const key = lockKey(record)
-  const fld = segment === undefined ? 'all' : segment
+  const fld = record.segment === undefined ? 'all' : record.segment
   if (await redis.lock(key, fld, ttl())) {
-    return segment ? {segment, ...record} : {...record}
+    return record
   } else {
     return null;
   }
@@ -17,9 +21,13 @@ exports.lock = async function(redis, {segment, ...record}) {
 /**
  * Unlock an impression (or "all") in redis w/NO ERRORS
  */
-exports.unlock = async function(redis, {segment, ...record}) {
+exports.unlock = async function(redis, record) {
+  if (!record) {
+    return null;
+  }
+
   const key = lockKey(record)
-  const fld = segment === undefined ? 'all' : segment
+  const fld = record.segment === undefined ? 'all' : record.segment
   try {
     await redis.unlock(key, fld)
     return true
@@ -32,11 +40,15 @@ exports.unlock = async function(redis, {segment, ...record}) {
 /**
  * Lock a listener-episode to a digest
  */
-exports.lockDigest = async function(redis, {digest, ...record}) {
-  if (await redis.lockValue(digestKey(record), digest, ttl())) {
-    return {digest, ...record}
+exports.lockDigest = async function(redis, record) {
+  if (!record) {
+    return null;
+  }
+
+  if (await redis.lockValue(digestKey(record), record.digest, ttl())) {
+    return record
   } else {
-    return {digest, isDuplicate: true, cause: 'digestCache', ...record}
+    return {isDuplicate: true, cause: 'digestCache', ...record}
   }
 }
 

--- a/lib/kinesis-lock.test.js
+++ b/lib/kinesis-lock.test.js
@@ -1,0 +1,98 @@
+const log = require('lambda-log')
+const lock = require('./kinesis-lock')
+const RedisBackup = require('./redis-backup')
+
+describe('kinesis-lock', () => {
+
+  let redis, overall, segment
+  beforeEach(() => {
+    redis = new RedisBackup(process.env.REDIS_URL)
+    overall = {
+      listenerEpisode: '1234',
+      digest: '5678',
+      timestamp: 9,
+      bytes: 10,
+      seconds: 12,
+      percent: 0.4
+    }
+    segment = {...overall, segment: 2}
+  })
+
+  afterEach(async () => {
+    await redis.nuke('dtcounts:imp:1234:*')
+    await redis.nuke('dtcounts:imp:1235:*')
+    await redis.disconnect()
+  })
+
+  it('locks the overall download', async () => {
+    expect(await lock.lock(redis, overall)).toEqual(overall)
+    expect(await lock.lock(redis, overall)).toEqual(null)
+
+    const changed = {...overall, listenerEpisode: '1235'}
+    expect(await lock.lock(redis, changed)).toEqual(changed)
+    expect(await lock.lock(redis, changed)).toEqual(null)
+
+    expect(await redis.cmd('hgetall', 'dtcounts:imp:1234:1970-01-01:5678')).toEqual({all: ''})
+    expect(await redis.cmd('hgetall', 'dtcounts:imp:1235:1970-01-01:5678')).toEqual({all: ''})
+  })
+
+  it('locks segment impressions', async () => {
+    expect(await lock.lock(redis, segment)).toEqual(segment)
+    expect(await lock.lock(redis, segment)).toEqual(null)
+
+    const changed = {...segment, segment: 3}
+    expect(await lock.lock(redis, changed)).toEqual(changed)
+    expect(await lock.lock(redis, changed)).toEqual(null)
+
+    expect(await redis.cmd('hgetall', 'dtcounts:imp:1234:1970-01-01:5678')).toEqual({2: '', 3: ''})
+  })
+
+  it('unlocks overall downloads', async () => {
+    expect(await lock.lock(redis, overall)).toEqual(overall)
+    expect(await redis.cmd('hgetall', 'dtcounts:imp:1234:1970-01-01:5678')).toEqual({all: ''})
+    expect(await lock.unlock(redis, overall)).toEqual(true)
+    expect(await redis.cmd('hgetall', 'dtcounts:imp:1234:1970-01-01:5678')).toEqual({})
+  })
+
+  it('unlocks segment impressions', async () => {
+    expect(await lock.lock(redis, segment)).toEqual(segment)
+    expect(await redis.cmd('hgetall', 'dtcounts:imp:1234:1970-01-01:5678')).toEqual({2: ''})
+    expect(await lock.unlock(redis, segment)).toEqual(true)
+    expect(await redis.cmd('hgetall', 'dtcounts:imp:1234:1970-01-01:5678')).toEqual({})
+  })
+
+  it('ignores unlock errors', async () => {
+    await redis.set('dtcounts:imp:1234:1970-01-01:5678', 'string-value')
+    jest.spyOn(log, 'warn').mockImplementation(() => null)
+
+    expect(await lock.unlock(redis, segment)).toEqual(false)
+    expect(log.warn).toHaveBeenCalledTimes(1)
+    expect(log.warn.mock.calls[0][0].message).toMatch(/WRONGTYPE/)
+    expect(log.warn.mock.calls[0][1]).toMatchObject({
+      key: 'dtcounts:imp:1234:1970-01-01:5678',
+      fld: 2,
+      msg: 'Kinesis unlock failed'
+    })
+  })
+
+  it('locks overall download digests', async () => {
+    expect(await lock.lockDigest(redis, overall)).toEqual(overall)
+    expect(await lock.lockDigest(redis, overall)).toEqual(overall)
+    expect(await redis.get('dtcounts:imp:1234:1970-01-01:digest')).toEqual('5678')
+
+    const changed = {...overall, digest: '5679'}
+    expect(await lock.lockDigest(redis, changed)).toEqual({...changed, isDuplicate: true, cause: 'digestCache'})
+    expect(await redis.get('dtcounts:imp:1234:1970-01-01:digest')).toEqual('5678')
+  })
+
+  it('locks segment impression digests', async () => {
+    expect(await lock.lockDigest(redis, segment)).toEqual(segment)
+    expect(await lock.lockDigest(redis, segment)).toEqual(segment)
+    expect(await redis.get('dtcounts:imp:1234:1970-01-01:digest')).toEqual('5678')
+
+    const changed = {...segment, digest: '5679'}
+    expect(await lock.lockDigest(redis, changed)).toEqual({...changed, isDuplicate: true, cause: 'digestCache'})
+    expect(await redis.get('dtcounts:imp:1234:1970-01-01:digest')).toEqual('5678')
+  })
+
+})

--- a/lib/kinesis-lock.test.js
+++ b/lib/kinesis-lock.test.js
@@ -7,14 +7,7 @@ describe('kinesis-lock', () => {
   let redis, overall, segment
   beforeEach(() => {
     redis = new RedisBackup(process.env.REDIS_URL)
-    overall = {
-      listenerEpisode: '1234',
-      digest: '5678',
-      timestamp: 9,
-      bytes: 10,
-      seconds: 12,
-      percent: 0.4
-    }
+    overall = {listenerEpisode: '1234', digest: '5678', timestamp: 9, bytes: 10, seconds: 12, percent: 0.4}
     segment = {...overall, segment: 2}
   })
 
@@ -65,6 +58,17 @@ describe('kinesis-lock', () => {
     expect(await redis.cmd('hgetall', 'dtcounts:imp:1234:1970-01-01:5678')).toEqual({2: ''})
     expect(await lock.unlock(redis, segment)).toEqual(true)
     expect(await redis.cmd('hgetall', 'dtcounts:imp:1234:1970-01-01:5678')).toEqual({})
+  })
+
+  it('knows if something is locked', async () => {
+    expect(await lock.isLocked(redis, overall)).toEqual(false)
+    expect(await lock.isLocked(redis, segment)).toEqual(false)
+
+    await lock.lock(redis, overall)
+    await lock.lock(redis, segment)
+
+    expect(await lock.isLocked(redis, overall)).toEqual(true)
+    expect(await lock.isLocked(redis, segment)).toEqual(true)
   })
 
   it('ignores unlock errors', async () => {

--- a/lib/kinesis-lock.test.js
+++ b/lib/kinesis-lock.test.js
@@ -24,6 +24,12 @@ describe('kinesis-lock', () => {
     await redis.disconnect()
   })
 
+  it('ignores nulls', async () => {
+    expect(await lock.lock(redis, null)).toEqual(null)
+    expect(await lock.unlock(redis, null)).toEqual(null)
+    expect(await lock.lockDigest(redis, null)).toEqual(null)
+  })
+
   it('locks the overall download', async () => {
     expect(await lock.lock(redis, overall)).toEqual(overall)
     expect(await lock.lock(redis, overall)).toEqual(null)

--- a/lib/kinesis.js
+++ b/lib/kinesis.js
@@ -1,122 +1,126 @@
 const AWS = require('aws-sdk')
 const crypto = require('crypto')
 const log = require('lambda-log')
-const { KinesisPutError } = require('./errors')
+const lock = require('./kinesis-lock')
+const { KinesisPutError, MissingEnvError } = require('./errors')
 const kinesis = new AWS.Kinesis({region: 'us-east-1'})
-const DEFAULT_TTL = 86400
+
+// export putRecords call, for testing/mocking
+exports._putRecords = opts => kinesis.putRecords(opts).promise()
 
 /**
- * Actual kinesis call
+ * Formatted kinesis impression records
  */
-exports._putRecord = function(opts) {
-  return kinesis.putRecord(opts).promise()
-}
-
-/**
- * Wrapper for kinesis putRecord
- */
-exports.putRecord = async function(StreamName, Data, PartitionKey = null) {
-  if (typeof Data !== 'string') {
-    Data = JSON.stringify(Data)
+exports.format = function({time, le, digest, segment, bytes, seconds, percent}) {
+  let rec = {
+    timestamp: time || new Date().getTime(),
+    listenerEpisode: le,
+    digest: digest,
   }
-  if (!PartitionKey) {
-    PartitionKey = crypto.createHash('md5').update(Data).digest('hex')
-  }
-  try {
-    await exports._putRecord({Data, StreamName, PartitionKey})
-    return true
-  } catch (err) {
-    const wrapped = new KinesisPutError(`Kinesis putRecord failed for ${StreamName}`, err)
-    log.warn(wrapped)
-    return false
-  }
-}
-
-/**
- * Record missing digests
- */
-exports.putMissingDigest = async function(digest) {
-  const stream = getStream('KINESIS_ARRANGEMENT_STREAM')
-  if (stream) {
-    return await exports.putRecord(stream, digest)
+  if (segment === undefined) {
+    rec.type = 'bytes'
+    rec.bytes = bytes
+    rec.seconds = round(seconds, 2)
+    rec.percent = round(percent, 4)
   } else {
-    return null
+    rec.type = 'segmentbytes'
+    rec.segment = segment
   }
+  return rec
 }
 
 /**
- * Record bigquery impressions with redis lock
+ * Lock redis and put records to kinesis
  */
-exports.putImpressionLock = async function(redis, {le, digest, time, segment, ...data}) {
-  const day = (time ? new Date(time) : new Date).toISOString().substr(0, 10)
-  const key = `dtcounts:imp:${le}:${day}:${digest}`
-  const fld = segment === undefined ? 'all' : segment
-  const ttl = process.env.REDIS_IMPRESSION_TTL || DEFAULT_TTL
-  if (await redis.lock(key, fld, ttl)) {
+exports.putWithLock = async function(redis, datas = [], maxChunk = 200) {
+  if (datas.length === 0) {
+    return 0
+  } else if (datas.length > maxChunk) {
+    const chunks = chunkArray(datas, maxChunk)
+    const nums = await Promise.all(chunks.map(c => exports.putWithLock(redis, c, maxChunk)))
+    return nums.reduce((a, b) => a + b, 0)
+  } else {
+    const records = datas.map(data => exports.format(data))
+
+    // lock the segments/overall so we only fire once
+    const locked = await Promise.all(records.map(rec => lock.lock(redis, rec)))
+
     // TODO: this is a bit temporary, but for now lock a listener-episode to
     // the 1st digest they download for that day.  mark downloads of any
     // other digest as duplicates
-    if (await redis.lockValue(`dtcounts:imp:${le}:${day}:digest`, digest, ttl)) {
-      return await exports.putImpression({...data, le, digest, time, segment})
-    } else {
-      await exports.putImpression({...data, le, digest, time, segment, dup: true})
-      return false
+    const digestLocked = await(Promise.all(locked.map(rec => lock.lockDigest(redis, rec))))
+
+    // log to kinesis
+    const nonNulls = digestLocked.filter(rec => rec)
+    const result = await putRecords(nonNulls)
+
+    // unlock anything that failed (NOTE: this does not remove the digestLock,
+    // as we have no way of knowing which already existed before now)
+    await Promise.all(result.failed.map(data => lock.unlock(redis, data)))
+
+    // throw a retryable error if we failed any kinesis putRecords
+    if (result.failed.length > 0) {
+      throw new KinesisPutError(`Failed to put ${result.failed.length} kinesis records`)
     }
-  } else {
-    return false
+
+    // return the number of non-dup putRecords
+    return result.succeeded.filter(rec => !rec.isDuplicate).length
   }
 }
 
-/**
- * Record bigquery impressions
- */
-exports.putImpression = async function({time, le, digest, segment, bytes, seconds, percent, dup}) {
-  const stream = getStream('KINESIS_IMPRESSION_STREAM')
-  if (stream) {
-    let rec = {
-      timestamp: time || new Date().getTime(),
-      listenerEpisode: le,
-      digest: digest,
-    }
-    if (segment === undefined) {
-      rec.type = 'bytes'
-      rec.bytes = bytes
-      rec.seconds = round(seconds, 2)
-      rec.percent = round(percent, 4)
-    } else {
-      rec.type = 'segmentbytes'
-      rec.segment = segment
-    }
-    if (dup) {
-      rec.isDuplicate = true
-      rec.cause = 'digestCache'
-    }
-    return await exports.putRecord(stream, rec, le)
-  } else {
-    return null
+// split array into chunks of max-size
+function chunkArray(array, maxSize) {
+  let i = 0;
+  const chunks = [];
+  const n = array.length;
+  while (i < n) {
+    chunks.push(array.slice(i, i += maxSize));
   }
+  return chunks;
 }
 
-/**
- * Lookup a stream name from an ENV variable
- */
-function getStream(name) {
-  if (process.env[name]) {
-    const val = process.env[name]
-    if (val.indexOf('/') > -1) {
-      return val.split('/').pop()
-    } else {
-      return val
-    }
-  } else {
-    return false
-  }
-}
-
-/**
- * Round floats to something sane
- */
+// Round floats to something sane
 function round(num, places) {
   const mult = Math.pow(10, places)
   return Math.round(num * mult) / mult
+}
+
+// batch put kinesis records, returning succeeding/failing records
+async function putRecords(rawRecords) {
+  if (rawRecords.length === 0) {
+    return {succeeded: [], failed: []}
+  }
+
+  let StreamName = process.env['KINESIS_IMPRESSION_STREAM']
+  if (!StreamName) {
+    throw new MissingEnvError('You must set KINESIS_IMPRESSION_STREAM')
+  } else if (StreamName.indexOf('/') > -1) {
+    StreamName = StreamName.split('/').pop()
+  }
+
+  const Records = rawRecords.map(rec => {
+    const Data = JSON.stringify(rec)
+    const PartitionKey = rec.listenerEpisode
+    return {Data, PartitionKey}
+  })
+
+  try {
+    const succeeded = []
+    const failed = []
+    const result = await exports._putRecords({StreamName, Records})
+    result.Records.forEach(({ErrorCode, ErrorMessage}, idx) => {
+      if (ErrorCode) {
+        const err = new KinesisPutError('Kinesis putRecords partial failure')
+        log.warn(err, {ErrorCode, ErrorMessage, Record: Records[idx]})
+        failed.push(rawRecords[idx])
+      } else {
+        succeeded.push(rawRecords[idx])
+      }
+    })
+    return {succeeded, failed}
+  } catch (err) {
+    const wrapped = new KinesisPutError(`Kinesis putRecords failure`, err)
+    log.warn(wrapped, {Records})
+    return {succeeded: [], failed: rawRecords}
+  }
 }

--- a/lib/kinesis.js
+++ b/lib/kinesis.js
@@ -36,7 +36,7 @@ exports.format = function({time, le, digest, segment, bytes, seconds, percent}) 
 /**
  * Lock redis and put records to kinesis
  */
-exports.putWithLock = async function(redis, datas = [], maxChunk = 200) {
+exports.putWithLock = async function(redis, datas = [], maxChunk = 400) {
   if (datas.length === 0) {
     return {overall: 0, segments: 0, overallDups: 0, segmentDups: 0, failed: 0}
   } else if (datas.length > maxChunk) {

--- a/lib/kinesis.js
+++ b/lib/kinesis.js
@@ -3,7 +3,11 @@ const crypto = require('crypto')
 const log = require('lambda-log')
 const lock = require('./kinesis-lock')
 const { KinesisPutError, MissingEnvError } = require('./errors')
-const kinesis = new AWS.Kinesis({region: 'us-east-1'})
+
+// note: these timeouts MUST be less than the execution timeout of the lambda,
+// or else redis lock rollbacks will not work correctly
+const httpOptions = {connectTimeout: 2000, timeout: 10000}
+const kinesis = new AWS.Kinesis({region: 'us-east-1', httpOptions})
 
 // export putRecords call, for testing/mocking
 exports._putRecords = opts => kinesis.putRecords(opts).promise()
@@ -34,11 +38,18 @@ exports.format = function({time, le, digest, segment, bytes, seconds, percent}) 
  */
 exports.putWithLock = async function(redis, datas = [], maxChunk = 200) {
   if (datas.length === 0) {
-    return 0
+    return {overall: 0, segments: 0, overallDups: 0, segmentDups: 0, failed: 0}
   } else if (datas.length > maxChunk) {
     const chunks = chunkArray(datas, maxChunk)
-    const nums = await Promise.all(chunks.map(c => exports.putWithLock(redis, c, maxChunk)))
-    return nums.reduce((a, b) => a + b, 0)
+    const counts = await Promise.all(chunks.map(c => exports.putWithLock(redis, c, maxChunk)))
+    return counts.reduce((acc, result) => {
+      if (acc) {
+        Object.keys(result).forEach(k => acc[k] += result[k])
+        return acc
+      } else {
+        return result
+      }
+    })
   } else {
     const records = datas.map(data => exports.format(data))
 
@@ -58,13 +69,14 @@ exports.putWithLock = async function(redis, datas = [], maxChunk = 200) {
     // as we have no way of knowing which already existed before now)
     await Promise.all(result.failed.map(data => lock.unlock(redis, data)))
 
-    // throw a retryable error if we failed any kinesis putRecords
-    if (result.failed.length > 0) {
-      throw new KinesisPutError(`Failed to put ${result.failed.length} kinesis records`)
+    // return the counts of what we did
+    return {
+      overall: result.succeeded.filter(rec => rec.type === 'bytes' && !rec.isDuplicate).length,
+      segments: result.succeeded.filter(rec => rec.type === 'segmentbytes' && !rec.isDuplicate).length,
+      overallDups: result.succeeded.filter(rec => rec.type === 'bytes' && rec.isDuplicate).length,
+      segmentDups: result.succeeded.filter(rec => rec.type === 'segmentbytes' && rec.isDuplicate).length,
+      failed: result.failed.length
     }
-
-    // return the number of non-dup putRecords
-    return result.succeeded.filter(rec => !rec.isDuplicate).length
   }
 }
 

--- a/lib/kinesis.test.js
+++ b/lib/kinesis.test.js
@@ -85,12 +85,12 @@ describe('kinesis', () => {
   })
 
   it('puts nothing', async () => {
-    expect(await kinesis.putWithLock(redis, [])).toEqual(0)
+    expect(await kinesis.putWithLock(redis, [])).toMatchObject({overall: 0, segments: 0})
   })
 
   it('puts formatted records to kinesis', async () => {
     const calls = mockPutRecords(true, true)
-    expect(await kinesis.putWithLock(redis, [overall, segment])).toEqual(2)
+    expect(await kinesis.putWithLock(redis, [overall, segment])).toMatchObject({overall: 1, segments: 1})
     expect(calls.length).toEqual(1)
     expect(calls[0].StreamName).toEqual('some-good-stream')
     expect(calls[0].Records.length).toEqual(2)
@@ -103,9 +103,9 @@ describe('kinesis', () => {
   it('only puts an overall download once', async () => {
     const calls = mockPutRecords(true)
     expect(await isLocked(overall)).toEqual(false)
-    expect(await kinesis.putWithLock(redis, [overall, overall, overall])).toEqual(1)
-    expect(await kinesis.putWithLock(redis, [overall])).toEqual(0)
-    expect(await kinesis.putWithLock(redis, [overall, overall])).toEqual(0)
+    expect(await kinesis.putWithLock(redis, [overall, overall, overall])).toMatchObject({overall: 1})
+    expect(await kinesis.putWithLock(redis, [overall])).toMatchObject({overall: 0})
+    expect(await kinesis.putWithLock(redis, [overall, overall])).toMatchObject({overall: 0})
     expect(calls.length).toEqual(1)
     expect(calls[0].Records.length).toEqual(1)
     expect(await isLocked(overall)).toEqual(true)
@@ -114,9 +114,9 @@ describe('kinesis', () => {
   it('only puts a segment impression once', async () => {
     const calls = mockPutRecords(true)
     expect(await isLocked(segment)).toEqual(false)
-    expect(await kinesis.putWithLock(redis, [segment, segment])).toEqual(1)
-    expect(await kinesis.putWithLock(redis, [segment, segment, segment])).toEqual(0)
-    expect(await kinesis.putWithLock(redis, [segment])).toEqual(0)
+    expect(await kinesis.putWithLock(redis, [segment, segment])).toMatchObject({segments: 1})
+    expect(await kinesis.putWithLock(redis, [segment, segment, segment])).toMatchObject({segments: 0})
+    expect(await kinesis.putWithLock(redis, [segment])).toMatchObject({segments: 0})
     expect(calls.length).toEqual(1)
     expect(calls[0].Records.length).toEqual(1)
     expect(await isLocked(segment)).toEqual(true)
@@ -125,23 +125,16 @@ describe('kinesis', () => {
   it('unlocks kinesis partial failures', async () => {
     const calls = mockPutRecords(false, true, true)
 
-    try {
-      jest.spyOn(log, 'warn').mockImplementation(() => null)
-      expect(await kinesis.putWithLock(redis, [overall, segment])).toEqual(1)
-      fail('should have gotten an error')
-    } catch (err) {
-      expect(err.name).toEqual('KinesisPutError')
-      expect(err.retryable).toEqual(true)
-      expect(err.message).toMatch(/failed to put 1/i)
-      expect(await isLocked(overall)).toEqual(false)
-      expect(await isLocked(segment)).toEqual(true)
-    }
+    jest.spyOn(log, 'warn').mockImplementation(() => null)
+    expect(await kinesis.putWithLock(redis, [overall, segment])).toMatchObject({segments: 1, failed: 1})
+    expect(await isLocked(overall)).toEqual(false)
+    expect(await isLocked(segment)).toEqual(true)
 
     expect(log.warn).toHaveBeenCalledTimes(1)
     expect(log.warn.mock.calls[0][0].message).toMatch('putRecords partial failure')
     expect(log.warn.mock.calls[0][1]).toMatchObject({ErrorCode: 'anything'})
 
-    expect(await kinesis.putWithLock(redis, [overall, segment])).toEqual(1)
+    expect(await kinesis.putWithLock(redis, [overall, segment])).toMatchObject({overall: 1})
     expect(calls.length).toEqual(2)
     expect(calls[0].Records.length).toEqual(2) // overall=failed, segment=success
     expect(calls[1].Records.length).toEqual(1) // overall=success
@@ -154,16 +147,9 @@ describe('kinesis', () => {
       throw new Error('Complete failure!')
     })
 
-    try {
-      jest.spyOn(log, 'warn').mockImplementation(() => null)
-      expect(await kinesis.putWithLock(redis, [overall])).toEqual(0)
-      fail('should have gotten an error')
-    } catch (err) {
-      expect(err.name).toEqual('KinesisPutError')
-      expect(err.retryable).toEqual(true)
-      expect(err.message).toMatch(/failed to put 1/i)
-      expect(await isLocked(overall)).toEqual(false)
-    }
+    jest.spyOn(log, 'warn').mockImplementation(() => null)
+    expect(await kinesis.putWithLock(redis, [overall])).toMatchObject({failed: 1})
+    expect(await isLocked(overall)).toEqual(false)
 
     expect(log.warn).toHaveBeenCalledTimes(1)
     expect(log.warn.mock.calls[0][0].message).toMatch('putRecords failure')
@@ -172,8 +158,8 @@ describe('kinesis', () => {
 
   it('locks to the first digest downloaded', async () => {
     const calls = mockPutRecords(true, true)
-    expect(await kinesis.putWithLock(redis, [overall])).toEqual(1)
-    expect(await kinesis.putWithLock(redis, [{...overall, digest: '5679'}])).toEqual(0)
+    expect(await kinesis.putWithLock(redis, [overall])).toMatchObject({overall: 1})
+    expect(await kinesis.putWithLock(redis, [{...overall, digest: '5679'}])).toMatchObject({overallDups: 1})
     expect(calls.length).toEqual(2)
     expect(calls[0].Records.length).toEqual(1)
     expect(JSON.parse(calls[0].Records[0].Data).isDuplicate).toBeUndefined()
@@ -185,17 +171,10 @@ describe('kinesis', () => {
   it('unfortunately does not unlock the digest for a failed putRecord', async () => {
     const calls = mockPutRecords(false, true)
 
-    try {
-      jest.spyOn(log, 'warn').mockImplementation(() => null)
-      expect(await kinesis.putWithLock(redis, [segment])).toEqual(0)
-      fail('should have gotten an error')
-    } catch (err) {
-      expect(err.name).toEqual('KinesisPutError')
-      expect(err.retryable).toEqual(true)
-      expect(err.message).toMatch(/failed to put 1/i)
-    }
+    jest.spyOn(log, 'warn').mockImplementation(() => null)
+    expect(await kinesis.putWithLock(redis, [segment])).toMatchObject({failed: 1})
 
-    expect(await kinesis.putWithLock(redis, [{...segment, digest: '5679'}])).toEqual(0)
+    expect(await kinesis.putWithLock(redis, [{...segment, digest: '5679'}])).toMatchObject({segmentDups: 1})
     expect(calls.length).toEqual(2)
     expect(calls[1].Records.length).toEqual(1)
     expect(JSON.parse(calls[1].Records[0].Data).isDuplicate).toEqual(true)
@@ -210,7 +189,13 @@ describe('kinesis', () => {
       {...overall, le: '1235'}
     ]
 
-    expect(await kinesis.putWithLock(redis, manyRecords, 3)).toEqual(4)
+    expect(await kinesis.putWithLock(redis, manyRecords, 3)).toMatchObject({
+      overall: 2,
+      overallDups: 0,
+      segments: 2,
+      segmentDups: 0,
+      failed: 0
+    })
     expect(calls.length).toEqual(3)
 
     expect(calls[0].Records.length).toEqual(1)

--- a/lib/kinesis.test.js
+++ b/lib/kinesis.test.js
@@ -1,139 +1,227 @@
 const log = require('lambda-log')
 const kinesis = require('./kinesis')
+const lock = require('./kinesis-lock')
 const RedisBackup = require('./redis-backup')
 
 describe('kinesis', () => {
 
-  let lastData, allDatas
+  let redis, overall, segment
   beforeEach(() => {
-    allDatas = []
-    process.env.KINESIS_IMPRESSION_STREAM = 'stream-good'
-    jest.spyOn(kinesis, '_putRecord').mockImplementation(async ({Data, StreamName, PartitionKey}) => {
-      if (StreamName === 'stream-good') {
-        lastData = Data
-        allDatas.push(Data)
-        return {mock: 'success'}
-      } else if (StreamName === 'stream-bad') {
-        throw new Error('Something something wrong')
-      } else {
-        throw new Error(`Unmocked kinesis request for ${StreamName}`)
-      }
+    redis = new RedisBackup(process.env.REDIS_URL)
+    overall = {le: '1234', digest: '5678', time: 9, bytes: 10, seconds: 12, percent: 0.4}
+    segment = {...overall, segment: 2}
+    process.env.KINESIS_IMPRESSION_STREAM = 'some-good-stream'
+  })
+
+  afterEach(async () => {
+    await redis.nuke('dtcounts:imp:1234:*')
+    await redis.nuke('dtcounts:imp:1235:*')
+    await redis.disconnect()
+    jest.restoreAllMocks()
+  })
+
+  // mock each kinesis.putRecords() batch call, and success/failure statuses
+  function mockPutRecords(...isSuccessList) {
+    let idx = 0, calls = []
+    jest.spyOn(kinesis, '_putRecords').mockImplementation(async function(args) {
+      calls.push(args)
+      return {Records: args.Records.map(() => {
+        const isSuccess = isSuccessList[idx++]
+        if (isSuccess === true) {
+          return {SequenceNumber: 'anything', ShardId: 'anything'}
+        } else if (isSuccess === false) {
+          return {ErrorCode: 'anything', ErrorMessage: 'anything'}
+        } else {
+          throw new Error(`Unmocked kinesis result ${idx}`)
+        }
+      })}
     })
-  })
+    return calls
+  }
 
-  afterEach(() => jest.restoreAllMocks())
+  // manually check for a lock
+  function isLocked(rec) {
+    return lock.isLocked(redis, kinesis.format(rec))
+  }
 
-  it('puts records', async () => {
-    expect(await kinesis.putRecord('stream-good', 'mock-data')).toEqual(true)
-  })
-
-  it('warns kinesis errors', async () => {
-    jest.spyOn(log, 'warn').mockImplementation(() => null)
-    expect(await kinesis.putRecord('stream-bad', 'mock-data')).toEqual(false)
-    expect(log.warn).toHaveBeenCalledTimes(1)
-    expect(log.warn.mock.calls[0][0].toString()).toMatch('KinesisPutError: Kinesis putRecord failed for stream-bad')
-    expect(log.warn.mock.calls[0][0].toString()).toMatch('Something something wrong')
-  })
-
-  it('puts missing arrangement digests', async () => {
-    process.env.KINESIS_ARRANGEMENT_STREAM = ''
-    expect(await kinesis.putMissingDigest('1234')).toEqual(null)
-    process.env.KINESIS_ARRANGEMENT_STREAM = 'stream-good'
-    expect(await kinesis.putMissingDigest('1234')).toEqual(true)
-  })
-
-  it('puts bigquery impressions', async () => {
-    process.env.KINESIS_IMPRESSION_STREAM = ''
-    expect(await kinesis.putImpression({le: '1234', digest: '5678'})).toEqual(null)
-    process.env.KINESIS_IMPRESSION_STREAM = 'stream-good'
-    expect(await kinesis.putImpression({le: '1234', digest: '5678'})).toEqual(true)
-  })
-
-  it('puts impressions data', async () => {
-    expect(await kinesis.putImpression({le: '1234', digest: '5678', time: 9, bytes: 10, seconds: 12, percent: 0.4})).toEqual(true)
-    expect(JSON.parse(lastData)).toEqual({
+  it('formats overall download records', () => {
+    expect(kinesis.format(overall)).toEqual({
       type: 'bytes',
-      timestamp: 9,
       listenerEpisode: '1234',
       digest: '5678',
+      timestamp: 9,
       bytes: 10,
       seconds: 12,
-      percent: 0.4,
+      percent: 0.4
     })
   })
 
-  it('rounds download seconds and percents', async () => {
-    expect(await kinesis.putImpression({seconds: 12.12345678, percent: 0.987654321})).toEqual(true)
-    expect(JSON.parse(lastData).seconds).toEqual(12.12)
-    expect(JSON.parse(lastData).percent).toEqual(0.9877)
-  })
-
-  it('puts segment impressions data', async () => {
-    expect(await kinesis.putImpression({le: '1234', digest: '5678', segment: 0, time: 1})).toEqual(true)
-    expect(JSON.parse(lastData)).toMatchObject({
+  it('formats segment impression records', () => {
+    expect(kinesis.format(segment)).toEqual({
       type: 'segmentbytes',
+      segment: 2,
       listenerEpisode: '1234',
       digest: '5678',
-      segment: 0,
-      timestamp: 1,
+      timestamp: 9
     })
   })
 
-  describe('with a redis connection', () => {
-
-    let redis
-    beforeEach(async () => {
-      redis = new RedisBackup(process.env.REDIS_URL)
+  it('rounds seconds and percents', () => {
+    expect(kinesis.format({...overall, seconds: 0.123456, percent: 0.123456})).toMatchObject({
+      seconds: 0.12,
+      percent: 0.1235
     })
-    afterEach(async () => {
-      await redis.nuke('dtcounts:imp:1234:*')
-      await redis.nuke('dtcounts:imp:1235:*')
-      await redis.disconnect()
+  })
+
+  it('requires a kinesis stream env', async () => {
+    try {
+      process.env.KINESIS_IMPRESSION_STREAM = ''
+      await kinesis.putWithLock(redis, [overall])
+      fail('should have gotten an error')
+    } catch (err) {
+      expect(err.name).toEqual('MissingEnvError')
+      expect(err.retryable).toEqual(true)
+    }
+  })
+
+  it('puts nothing', async () => {
+    expect(await kinesis.putWithLock(redis, [])).toEqual(0)
+  })
+
+  it('puts formatted records to kinesis', async () => {
+    const calls = mockPutRecords(true, true)
+    expect(await kinesis.putWithLock(redis, [overall, segment])).toEqual(2)
+    expect(calls.length).toEqual(1)
+    expect(calls[0].StreamName).toEqual('some-good-stream')
+    expect(calls[0].Records.length).toEqual(2)
+    expect(calls[0].Records[0].PartitionKey).toEqual('1234')
+    expect(JSON.parse(calls[0].Records[0].Data)).toEqual(kinesis.format(overall))
+    expect(calls[0].Records[1].PartitionKey).toEqual('1234')
+    expect(JSON.parse(calls[0].Records[1].Data)).toEqual(kinesis.format(segment))
+  })
+
+  it('only puts an overall download once', async () => {
+    const calls = mockPutRecords(true)
+    expect(await isLocked(overall)).toEqual(false)
+    expect(await kinesis.putWithLock(redis, [overall, overall, overall])).toEqual(1)
+    expect(await kinesis.putWithLock(redis, [overall])).toEqual(0)
+    expect(await kinesis.putWithLock(redis, [overall, overall])).toEqual(0)
+    expect(calls.length).toEqual(1)
+    expect(calls[0].Records.length).toEqual(1)
+    expect(await isLocked(overall)).toEqual(true)
+  })
+
+  it('only puts a segment impression once', async () => {
+    const calls = mockPutRecords(true)
+    expect(await isLocked(segment)).toEqual(false)
+    expect(await kinesis.putWithLock(redis, [segment, segment])).toEqual(1)
+    expect(await kinesis.putWithLock(redis, [segment, segment, segment])).toEqual(0)
+    expect(await kinesis.putWithLock(redis, [segment])).toEqual(0)
+    expect(calls.length).toEqual(1)
+    expect(calls[0].Records.length).toEqual(1)
+    expect(await isLocked(segment)).toEqual(true)
+  })
+
+  it('unlocks kinesis partial failures', async () => {
+    const calls = mockPutRecords(false, true, true)
+
+    try {
+      jest.spyOn(log, 'warn').mockImplementation(() => null)
+      expect(await kinesis.putWithLock(redis, [overall, segment])).toEqual(1)
+      fail('should have gotten an error')
+    } catch (err) {
+      expect(err.name).toEqual('KinesisPutError')
+      expect(err.retryable).toEqual(true)
+      expect(err.message).toMatch(/failed to put 1/i)
+      expect(await isLocked(overall)).toEqual(false)
+      expect(await isLocked(segment)).toEqual(true)
+    }
+
+    expect(log.warn).toHaveBeenCalledTimes(1)
+    expect(log.warn.mock.calls[0][0].message).toMatch('putRecords partial failure')
+    expect(log.warn.mock.calls[0][1]).toMatchObject({ErrorCode: 'anything'})
+
+    expect(await kinesis.putWithLock(redis, [overall, segment])).toEqual(1)
+    expect(calls.length).toEqual(2)
+    expect(calls[0].Records.length).toEqual(2) // overall=failed, segment=success
+    expect(calls[1].Records.length).toEqual(1) // overall=success
+    expect(await isLocked(overall)).toEqual(true)
+    expect(await isLocked(segment)).toEqual(true)
+  })
+
+  it('unlocks kinesis complete failures', async () => {
+    jest.spyOn(kinesis, '_putRecords').mockImplementation(async () => {
+      throw new Error('Complete failure!')
     })
 
-    it('locks the overall download', async () => {
-      const data = {le: '1234', digest: '5678', time: 9, bytes: 10, seconds: 12, percent: 0.4}
-      expect(await kinesis.putImpressionLock(redis, data)).toEqual(true)
-      expect(await kinesis.putImpressionLock(redis, data)).toEqual(false)
-      expect(await kinesis.putImpressionLock(redis, {...data, le: '1235'})).toEqual(true)
+    try {
+      jest.spyOn(log, 'warn').mockImplementation(() => null)
+      expect(await kinesis.putWithLock(redis, [overall])).toEqual(0)
+      fail('should have gotten an error')
+    } catch (err) {
+      expect(err.name).toEqual('KinesisPutError')
+      expect(err.retryable).toEqual(true)
+      expect(err.message).toMatch(/failed to put 1/i)
+      expect(await isLocked(overall)).toEqual(false)
+    }
 
-      expect(allDatas.length).toEqual(2)
-      expect(JSON.parse(allDatas[0])).toMatchObject({listenerEpisode: '1234', digest: '5678', bytes: 10})
-      expect(JSON.parse(allDatas[1])).toMatchObject({listenerEpisode: '1235', digest: '5678', bytes: 10})
-    })
+    expect(log.warn).toHaveBeenCalledTimes(1)
+    expect(log.warn.mock.calls[0][0].message).toMatch('putRecords failure')
+    expect(log.warn.mock.calls[0][1].Records.length).toEqual(1)
+  })
 
-    it('locks segment impressions', async () => {
-      const data = {le: '1234', digest: '5678', time: 9, bytes: 10, seconds: 12, percent: 0.4}
-      expect(await kinesis.putImpressionLock(redis, {...data, segment: 0})).toEqual(true)
-      expect(await kinesis.putImpressionLock(redis, {...data, segment: 0})).toEqual(false)
-      expect(await kinesis.putImpressionLock(redis, {...data, segment: 3})).toEqual(true)
-      expect(await kinesis.putImpressionLock(redis, {...data, segment: 2})).toEqual(true)
-      expect(await kinesis.putImpressionLock(redis, {...data, segment: 3})).toEqual(false)
+  it('locks to the first digest downloaded', async () => {
+    const calls = mockPutRecords(true, true)
+    expect(await kinesis.putWithLock(redis, [overall])).toEqual(1)
+    expect(await kinesis.putWithLock(redis, [{...overall, digest: '5679'}])).toEqual(0)
+    expect(calls.length).toEqual(2)
+    expect(calls[0].Records.length).toEqual(1)
+    expect(JSON.parse(calls[0].Records[0].Data).isDuplicate).toBeUndefined()
+    expect(calls[1].Records.length).toEqual(1)
+    expect(JSON.parse(calls[1].Records[0].Data).isDuplicate).toEqual(true)
+    expect(JSON.parse(calls[1].Records[0].Data).cause).toEqual('digestCache')
+  })
 
-      expect(allDatas.length).toEqual(3)
-      expect(JSON.parse(allDatas[0])).toMatchObject({listenerEpisode: '1234', digest: '5678', segment: 0})
-      expect(JSON.parse(allDatas[1])).toMatchObject({listenerEpisode: '1234', digest: '5678', segment: 3})
-      expect(JSON.parse(allDatas[2])).toMatchObject({listenerEpisode: '1234', digest: '5678', segment: 2})
-    })
+  it('unfortunately does not unlock the digest for a failed putRecord', async () => {
+    const calls = mockPutRecords(false, true)
 
-    it('locks the first digest to be downloaded each day', async () => {
-      const data = {le: '1234', digest: '5678', time: 9, bytes: 10, seconds: 12, percent: 0.4}
-      expect(await kinesis.putImpressionLock(redis, {...data, segment: 0})).toEqual(true)
-      expect(await kinesis.putImpressionLock(redis, {...data, digest: '5679'})).toEqual(false)
-      expect(await kinesis.putImpressionLock(redis, {...data, digest: '5679', segment: 3})).toEqual(false)
-      expect(await kinesis.putImpressionLock(redis, {...data, digest: '5679', time: 86400001})).toEqual(true)
-      expect(await kinesis.putImpressionLock(redis, {...data})).toEqual(true)
+    try {
+      jest.spyOn(log, 'warn').mockImplementation(() => null)
+      expect(await kinesis.putWithLock(redis, [segment])).toEqual(0)
+      fail('should have gotten an error')
+    } catch (err) {
+      expect(err.name).toEqual('KinesisPutError')
+      expect(err.retryable).toEqual(true)
+      expect(err.message).toMatch(/failed to put 1/i)
+    }
 
-      expect(allDatas.length).toEqual(5)
-      expect(JSON.parse(allDatas[0])).toMatchObject({digest: '5678', segment: 0})
-      expect(JSON.parse(allDatas[0]).isDuplicate).toBeUndefined()
-      expect(JSON.parse(allDatas[1])).toMatchObject({digest: '5679', isDuplicate: true, cause: 'digestCache'})
-      expect(JSON.parse(allDatas[2])).toMatchObject({digest: '5679', isDuplicate: true, cause: 'digestCache', segment: 3})
-      expect(JSON.parse(allDatas[3])).toMatchObject({digest: '5679', timestamp: 86400001})
-      expect(JSON.parse(allDatas[3]).isDuplicate).toBeUndefined()
-      expect(JSON.parse(allDatas[4])).toMatchObject({digest: '5678', timestamp: 9})
-    })
+    expect(await kinesis.putWithLock(redis, [{...segment, digest: '5679'}])).toEqual(0)
+    expect(calls.length).toEqual(2)
+    expect(calls[1].Records.length).toEqual(1)
+    expect(JSON.parse(calls[1].Records[0].Data).isDuplicate).toEqual(true)
+    expect(JSON.parse(calls[1].Records[0].Data).cause).toEqual('digestCache')
+  })
 
+  it('splits into batches', async () => {
+    const calls = mockPutRecords(true, true, true, true)
+    const manyRecords = [
+      overall, overall, overall,
+      segment, overall, {...segment, le: '1235'},
+      {...overall, le: '1235'}
+    ]
+
+    expect(await kinesis.putWithLock(redis, manyRecords, 3)).toEqual(4)
+    expect(calls.length).toEqual(3)
+
+    expect(calls[0].Records.length).toEqual(1)
+    expect(JSON.parse(calls[0].Records[0].PartitionKey)).toEqual(1234)
+
+    expect(calls[1].Records.length).toEqual(2)
+    expect(JSON.parse(calls[1].Records[0].PartitionKey)).toEqual(1234)
+    expect(JSON.parse(calls[1].Records[1].PartitionKey)).toEqual(1235)
+
+    expect(calls[2].Records.length).toEqual(1)
+    expect(JSON.parse(calls[2].Records[0].PartitionKey)).toEqual(1235)
   })
 
 })

--- a/lib/redis-backup.js
+++ b/lib/redis-backup.js
@@ -1,7 +1,6 @@
 const log = require('lambda-log')
 const IORedis = require('ioredis')
 const Redis = require('./redis')
-const { MissingEnvError } = require('./errors')
 
 /**
  * Wrapper for a redis connection, also sending SET commands to a backup redis

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -122,6 +122,11 @@ module.exports = class Redis {
     }
   }
 
+  async unlock(key, field) {
+    const res = await this.cmd('hdel', key, field)
+    return res === 1
+  }
+
   async nuke(pattern) {
     const keys = await this.cmd('keys', [pattern])
     return Promise.all(keys.map(k => this.del(k)))

--- a/lib/redis.test.js
+++ b/lib/redis.test.js
@@ -86,6 +86,17 @@ describe('redis', () => {
     expect(await redis.ttl(TEST_KEY)).toEqual(33)
   })
 
+  it('unlocks a key/field hash', async () => {
+    expect(await redis.lock(TEST_KEY, 'some-fld1')).toEqual(true)
+    expect(await redis.lock(TEST_KEY, 'some-fld2')).toEqual(true)
+
+    expect(await redis.unlock(TEST_KEY, 'some-fld2')).toEqual(true)
+    expect(await redis.unlock(TEST_KEY, 'some-fld3')).toEqual(false)
+
+    expect(await redis.lock(TEST_KEY, 'some-fld1')).toEqual(false)
+    expect(await redis.lock(TEST_KEY, 'some-fld2')).toEqual(true)
+  })
+
   it('gets valid json or null', async () => {
     expect(await redis.getJson(TEST_KEY)).toEqual(null)
     await redis.set(TEST_KEY, 'some-val')


### PR DESCRIPTION
For #18 and #19 (and #15).  Batch kinesis puts, and rollback any failures in the redis locks.

Major changes:

- `index.js` handler now processes _all_ byte-range accumulations before handing off to kinesis #18.  This slightly changes the API of the kinesis calls.
- `lib/kinesis.js` will no longer throw errors for any reason.  It just returns the succeeded/failed counts.  The handler should throw errors to retry any failed putRecords.
- `lib/kinesis.js` catches all errors, and rolls back redis locks for failed records #19
- `lib/arrangement.js` no longer logs kinesis records for older/missing arrangement versions - just log.warn them #15

The calls to `kinesis.putRecords` run in batches of 400.  AWS lists the max size as 500 records or 1MB, so seems prudent to stay a bit below that.

So records to put are split into chunks of 400, and the we call all the `putRecords()` _in parallel_, with a timeout (10s) of less than the execution limit of the lambda (20s).  Any failed chunks (or partial failures) are unlocked in Redis, so replaying them can still log a download/impression.

Then, after _all_ putRecords calls either succeed or fail, the handler logs the results and throws an error if any failed.  This will cause the entire kinesis batch to be retried - but anything that succeeded the 1st time will be locked in redis, and skipped on the next try.