### PR TITLE
Log sonic ids

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -166,15 +166,19 @@ describe('handler', () => {
     })
   })
 
-  it('does not count non-ad segments', async () => {
+  it('does not count original segments', async () => {
     s3.__addArrangement('itest-digest', {version: 4, data: {t: 'aobisa?', b: [1, 2, 3, 4, 5, 6, 7, 8], a: [128, 1, 44100]}})
     decoder.__addBytes({le: 'itest1', digest: 'itest-digest', time: 1, start: 0, end: 10})
 
-    expect(await handler()).toMatchObject({overall: 1, segments: 2})
-    expect(kinesis.__records.length).toEqual(3)
+    expect(await handler()).toMatchObject({overall: 1, segments: 6})
+    expect(kinesis.__records.length).toEqual(7)
     expect(kinesis.__records[0]).toMatchObject({type: 'bytes'})
     expect(kinesis.__records[1]).toMatchObject({type: 'segmentbytes', segment: 0})
-    expect(kinesis.__records[2]).toMatchObject({type: 'segmentbytes', segment: 5})
+    expect(kinesis.__records[2]).toMatchObject({type: 'segmentbytes', segment: 2})
+    expect(kinesis.__records[3]).toMatchObject({type: 'segmentbytes', segment: 3})
+    expect(kinesis.__records[4]).toMatchObject({type: 'segmentbytes', segment: 4})
+    expect(kinesis.__records[5]).toMatchObject({type: 'segmentbytes', segment: 5})
+    expect(kinesis.__records[6]).toMatchObject({type: 'segmentbytes', segment: 6})
   })
 
   it('it warns on bad arrangements', async () => {

--- a/lib/arrangement.js
+++ b/lib/arrangement.js
@@ -74,9 +74,9 @@ module.exports = class Arrangement {
     }
   }
 
-  // TODO: only logging "ad" segments (not original/billboard/sonicid/unknown)
+  // log all non-original segments
   isLoggable(idx) {
-    return this.types[idx] === 'a'
+    return !!this.types[idx] && this.types[idx] !== 'o'
   }
 
   encode() {

--- a/lib/arrangement.test.js
+++ b/lib/arrangement.test.js
@@ -169,15 +169,15 @@ describe('arrangement', () => {
     expect(arr.bytesToPercent(3)).toEqual(0.1)
   })
 
-  it('only logs ad-type segments', () => {
+  it('only logs non-original type segments', () => {
     const arr = new Arrangement(DIGEST, {version: 3, data: {t: 'aobisa?', b: [1, 2, 3, 4, 5, 6, 7, 8]}})
     expect(arr.isLoggable(0)).toEqual(true)
     expect(arr.isLoggable(1)).toEqual(false)
-    expect(arr.isLoggable(2)).toEqual(false)
-    expect(arr.isLoggable(3)).toEqual(false)
-    expect(arr.isLoggable(4)).toEqual(false)
+    expect(arr.isLoggable(2)).toEqual(true)
+    expect(arr.isLoggable(3)).toEqual(true)
+    expect(arr.isLoggable(4)).toEqual(true)
     expect(arr.isLoggable(5)).toEqual(true)
-    expect(arr.isLoggable(6)).toEqual(false)
+    expect(arr.isLoggable(6)).toEqual(true)
     expect(arr.isLoggable(99)).toEqual(false)
   })
 


### PR DESCRIPTION
For PRX/dovetail-router.prx.org#59.

Send `{type: 'segmentbytes', segment: 3}` kinesis records for all non-original segments.  This includes billboard, sonicId, and unknown segments - as defined in the [arrangement v1 spec](https://github.com/PRX/dovetail-stitch-lambda/blob/master/lib/arrangement/arrangement-v1.js#L7).  We were previously only sending "ad" segments.

This will allow the analytics-ingest-lambda to [retrieve those impressions](https://github.com/PRX/analytics-ingest-lambda/blob/master/lib/inputs/byte-downloads.js#L84) from DynamoDB.  Note that if there is no `{impressions: [{segment: 3, campaignId: 1234, flightId: 5678}]` impression in DDB matching the "segment" number, it doesn't log anything further to kinesis.

And although dovetail-router logs [any non-original as an impression](https://github.com/PRX/dovetail-router.prx.org/blob/master/lib/dovetail/structs/placement.ex#L27) ... dovetail classic [does not](https://github.com/PRX/dovetail.prx.org/blob/master/models/decision.js#L251).  So this PR will result in _slightly_ more records on the `dovetail-ddb-production` kinesis stream ... the bulk will be dovetail-classic downloads discarded by the analytics DDB lambda.