### PR TITLE
Upgrade ioredis

### DIFF
--- a/lib/kinesis-lock.test.js
+++ b/lib/kinesis-lock.test.js
@@ -7,13 +7,13 @@ describe('kinesis-lock', () => {
   let redis, overall, segment
   beforeEach(() => {
     redis = new RedisBackup(process.env.REDIS_URL)
-    overall = {listenerEpisode: '1234', digest: '5678', timestamp: 9, bytes: 10, seconds: 12, percent: 0.4}
+    overall = {listenerEpisode: '9999', digest: '5678', timestamp: 9, bytes: 10, seconds: 12, percent: 0.4}
     segment = {...overall, segment: 2}
   })
 
   afterEach(async () => {
-    await redis.nuke('dtcounts:imp:1234:*')
-    await redis.nuke('dtcounts:imp:1235:*')
+    await redis.nuke('dtcounts:imp:9999:*')
+    await redis.nuke('dtcounts:imp:8888:*')
     await redis.disconnect()
   })
 
@@ -27,12 +27,12 @@ describe('kinesis-lock', () => {
     expect(await lock.lock(redis, overall)).toEqual(overall)
     expect(await lock.lock(redis, overall)).toEqual(null)
 
-    const changed = {...overall, listenerEpisode: '1235'}
+    const changed = {...overall, listenerEpisode: '8888'}
     expect(await lock.lock(redis, changed)).toEqual(changed)
     expect(await lock.lock(redis, changed)).toEqual(null)
 
-    expect(await redis.cmd('hgetall', 'dtcounts:imp:1234:1970-01-01:5678')).toEqual({all: ''})
-    expect(await redis.cmd('hgetall', 'dtcounts:imp:1235:1970-01-01:5678')).toEqual({all: ''})
+    expect(await redis.cmd('hgetall', 'dtcounts:imp:9999:1970-01-01:5678')).toEqual({all: ''})
+    expect(await redis.cmd('hgetall', 'dtcounts:imp:8888:1970-01-01:5678')).toEqual({all: ''})
   })
 
   it('locks segment impressions', async () => {
@@ -43,21 +43,21 @@ describe('kinesis-lock', () => {
     expect(await lock.lock(redis, changed)).toEqual(changed)
     expect(await lock.lock(redis, changed)).toEqual(null)
 
-    expect(await redis.cmd('hgetall', 'dtcounts:imp:1234:1970-01-01:5678')).toEqual({2: '', 3: ''})
+    expect(await redis.cmd('hgetall', 'dtcounts:imp:9999:1970-01-01:5678')).toEqual({2: '', 3: ''})
   })
 
   it('unlocks overall downloads', async () => {
     expect(await lock.lock(redis, overall)).toEqual(overall)
-    expect(await redis.cmd('hgetall', 'dtcounts:imp:1234:1970-01-01:5678')).toEqual({all: ''})
+    expect(await redis.cmd('hgetall', 'dtcounts:imp:9999:1970-01-01:5678')).toEqual({all: ''})
     expect(await lock.unlock(redis, overall)).toEqual(true)
-    expect(await redis.cmd('hgetall', 'dtcounts:imp:1234:1970-01-01:5678')).toEqual({})
+    expect(await redis.cmd('hgetall', 'dtcounts:imp:9999:1970-01-01:5678')).toEqual({})
   })
 
   it('unlocks segment impressions', async () => {
     expect(await lock.lock(redis, segment)).toEqual(segment)
-    expect(await redis.cmd('hgetall', 'dtcounts:imp:1234:1970-01-01:5678')).toEqual({2: ''})
+    expect(await redis.cmd('hgetall', 'dtcounts:imp:9999:1970-01-01:5678')).toEqual({2: ''})
     expect(await lock.unlock(redis, segment)).toEqual(true)
-    expect(await redis.cmd('hgetall', 'dtcounts:imp:1234:1970-01-01:5678')).toEqual({})
+    expect(await redis.cmd('hgetall', 'dtcounts:imp:9999:1970-01-01:5678')).toEqual({})
   })
 
   it('knows if something is locked', async () => {
@@ -72,14 +72,14 @@ describe('kinesis-lock', () => {
   })
 
   it('ignores unlock errors', async () => {
-    await redis.set('dtcounts:imp:1234:1970-01-01:5678', 'string-value')
+    await redis.set('dtcounts:imp:9999:1970-01-01:5678', 'string-value')
     jest.spyOn(log, 'warn').mockImplementation(() => null)
 
     expect(await lock.unlock(redis, segment)).toEqual(false)
     expect(log.warn).toHaveBeenCalledTimes(1)
     expect(log.warn.mock.calls[0][0].message).toMatch(/WRONGTYPE/)
     expect(log.warn.mock.calls[0][1]).toMatchObject({
-      key: 'dtcounts:imp:1234:1970-01-01:5678',
+      key: 'dtcounts:imp:9999:1970-01-01:5678',
       fld: 2,
       msg: 'Kinesis unlock failed'
     })
@@ -88,21 +88,21 @@ describe('kinesis-lock', () => {
   it('locks overall download digests', async () => {
     expect(await lock.lockDigest(redis, overall)).toEqual(overall)
     expect(await lock.lockDigest(redis, overall)).toEqual(overall)
-    expect(await redis.get('dtcounts:imp:1234:1970-01-01:digest')).toEqual('5678')
+    expect(await redis.get('dtcounts:imp:9999:1970-01-01:digest')).toEqual('5678')
 
     const changed = {...overall, digest: '5679'}
     expect(await lock.lockDigest(redis, changed)).toEqual({...changed, isDuplicate: true, cause: 'digestCache'})
-    expect(await redis.get('dtcounts:imp:1234:1970-01-01:digest')).toEqual('5678')
+    expect(await redis.get('dtcounts:imp:9999:1970-01-01:digest')).toEqual('5678')
   })
 
   it('locks segment impression digests', async () => {
     expect(await lock.lockDigest(redis, segment)).toEqual(segment)
     expect(await lock.lockDigest(redis, segment)).toEqual(segment)
-    expect(await redis.get('dtcounts:imp:1234:1970-01-01:digest')).toEqual('5678')
+    expect(await redis.get('dtcounts:imp:9999:1970-01-01:digest')).toEqual('5678')
 
     const changed = {...segment, digest: '5679'}
     expect(await lock.lockDigest(redis, changed)).toEqual({...changed, isDuplicate: true, cause: 'digestCache'})
-    expect(await redis.get('dtcounts:imp:1234:1970-01-01:digest')).toEqual('5678')
+    expect(await redis.get('dtcounts:imp:9999:1970-01-01:digest')).toEqual('5678')
   })
 
 })

--- a/lib/kinesis.test.js
+++ b/lib/kinesis.test.js
@@ -198,15 +198,13 @@ describe('kinesis', () => {
     })
     expect(calls.length).toEqual(3)
 
-    expect(calls[0].Records.length).toEqual(1)
-    expect(JSON.parse(calls[0].Records[0].PartitionKey)).toEqual(1234)
+    // order of locks not guaranteed - but groupings are
+    const keys = calls.map(c => c.Records.map(r => r.PartitionKey))
+    const sorted = keys.sort((a, b) => JSON.stringify(a) < JSON.stringify(b))
 
-    expect(calls[1].Records.length).toEqual(2)
-    expect(JSON.parse(calls[1].Records[0].PartitionKey)).toEqual(1234)
-    expect(JSON.parse(calls[1].Records[1].PartitionKey)).toEqual(1235)
-
-    expect(calls[2].Records.length).toEqual(1)
-    expect(JSON.parse(calls[2].Records[0].PartitionKey)).toEqual(1235)
+    expect(sorted[0]).toEqual(['1235'])
+    expect(sorted[1]).toEqual(['1234'])
+    expect(sorted[2]).toEqual(['1234', '1235'])
   })
 
 })

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -29,7 +29,10 @@ module.exports = class Redis {
     // optionally run in cluster mode
     if (redisUrl.match(/^cluster:\/\/.+:[0-9]+$/)) {
       const parts = redisUrl.replace(/^cluster:\/\//, '').split(':')
-      this.conn = new IORedis.Cluster([{host: parts[0], port: parts[1]}], {redisOptions: opts})
+      this.conn = new IORedis.Cluster([{host: parts[0], port: parts[1]}], {
+        clusterRetryStrategy: opts.retryStrategy,
+        redisOptions: opts
+      })
     } else {
       this.conn = new IORedis(redisUrl, opts)
     }

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -128,7 +128,14 @@ module.exports = class Redis {
   }
 
   async nuke(pattern) {
-    const keys = await this.cmd('keys', [pattern])
+    let keys = []
+    if (this.conn instanceof IORedis.Cluster) {
+      for (let node of await this.conn.nodes()) {
+        keys = keys.concat(await node.keys(pattern))
+      }
+    } else {
+      keys = keys.concat(await this.cmd('keys', [pattern]))
+    }
     return Promise.all(keys.map(k => this.del(k)))
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -504,9 +504,10 @@ cliui@^4.0.0:
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
-cluster-key-slot@^1.0.6:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.0.12.tgz#d5deff2a520717bc98313979b687309b2d368e29"
+cluster-key-slot@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz#30474b2a981fb12172695833052bc0d01336d10d"
+  integrity sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==
 
 co@^4.6.0:
   version "4.6.0"
@@ -618,8 +619,16 @@ debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
     ms "2.0.0"
 
 debug@^3.1.0:
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.5.tgz#c2418fbfd7a29f4d4f70ff4cea604d4b64c46407"
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+  dependencies:
+    ms "^2.1.1"
+
+debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -679,8 +688,9 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
 denque@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/denque/-/denque-1.3.0.tgz#681092ef44a630246d3f6edb2a199230eae8e76b"
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.4.1.tgz#6744ff7641c148c3f8a69c307e51235c1f4a37cf"
+  integrity sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==
 
 detect-indent@^4.0.0:
   version "4.0.0"
@@ -937,10 +947,6 @@ find-up@^2.1.0:
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
     locate-path "^2.0.0"
-
-flexbuffer@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/flexbuffer/-/flexbuffer-0.0.6.tgz#039fdf23f8823e440c38f3277e6fef1174215b30"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -1222,30 +1228,19 @@ invert-kv@^1.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
 ioredis@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.0.0.tgz#fabf1cf8724f14fd0885233cf2f4fbc6e1e59da2"
+  version "4.17.1"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.17.1.tgz#06ef3d3b2cb96b7e6bc90a7b8839a33e743843ad"
+  integrity sha512-kfxkN/YO1dnyaoAGyNdH3my4A1eoGDy4QOfqn6o86fo4dTboxyxYVW0S0v/d3MkwCWlvSWhlwq6IJMY9BlWs6w==
   dependencies:
-    cluster-key-slot "^1.0.6"
-    debug "^3.1.0"
+    cluster-key-slot "^1.1.0"
+    debug "^4.1.1"
     denque "^1.1.0"
-    flexbuffer "0.0.6"
-    lodash.bind "^4.2.1"
-    lodash.clone "^4.5.0"
-    lodash.clonedeep "^4.5.0"
     lodash.defaults "^4.2.0"
-    lodash.difference "^4.5.0"
     lodash.flatten "^4.4.0"
-    lodash.foreach "^4.5.0"
-    lodash.isempty "^4.4.0"
-    lodash.partial "^4.2.1"
-    lodash.pick "^4.4.0"
-    lodash.sample "^4.2.1"
-    lodash.shuffle "^4.2.0"
-    lodash.values "^4.3.0"
-    redis-commands "^1.2.0"
+    redis-commands "1.5.0"
     redis-errors "^1.2.0"
     redis-parser "^3.0.0"
-    standard-as-callback "^1.0.0"
+    standard-as-callback "^2.0.1"
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
@@ -1949,61 +1944,19 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash.bind@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
-
-lodash.clone@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
-
-lodash.clonedeep@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-
 lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
-
-lodash.difference@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
+  integrity sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=
 
 lodash.flatten@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
-
-lodash.foreach@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
-
-lodash.isempty@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
-
-lodash.partial@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/lodash.partial/-/lodash.partial-4.2.1.tgz#49f3d8cfdaa3bff8b3a91d127e923245418961d4"
-
-lodash.pick@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
-
-lodash.sample@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/lodash.sample/-/lodash.sample-4.2.1.tgz#5e4291b0c753fa1abeb0aab8fb29df1b66f07f6d"
-
-lodash.shuffle@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.shuffle/-/lodash.shuffle-4.2.0.tgz#145b5053cf875f6f5c2a33f48b6e9948c6ec7b4b"
+  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
-
-lodash.values@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-4.3.0.tgz#a3a6c2b0ebecc5c2cba1c17e6e620fe81b53d347"
 
 lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4:
   version "4.17.11"
@@ -2157,8 +2110,9 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
 ms@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 nan@^2.9.2:
   version "2.11.0"
@@ -2582,17 +2536,20 @@ realpath-native@^1.0.0:
   dependencies:
     util.promisify "^1.0.0"
 
-redis-commands@^1.2.0:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.3.5.tgz#4495889414f1e886261180b1442e7295602d83a2"
+redis-commands@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.5.0.tgz#80d2e20698fe688f227127ff9e5164a7dd17e785"
+  integrity sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg==
 
 redis-errors@^1.0.0, redis-errors@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=
 
 redis-parser@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=
   dependencies:
     redis-errors "^1.0.0"
 
@@ -2912,9 +2869,10 @@ stack-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
 
-standard-as-callback@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-1.0.1.tgz#2e9e1e9d278d7d77580253faaec42269015e3c1d"
+standard-as-callback@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.0.1.tgz#ed8bb25648e15831759b6023bdb87e6b60b38126"
+  integrity sha512-NQOxSeB8gOI5WjSaxjBgog2QFw55FV8TkS6Y07BiB3VJ8xNTvUYm0wl0s8ObgQ5NhdpnNfigMIKjgPESzgr4tg==
 
 static-extend@^0.1.1:
   version "0.1.2"


### PR DESCRIPTION
Closes #27.

Upgrade ioredis from 4.0.0 -> 4.17.1 to get a bunch of good redis-cluster bugfixes.

I looked into some of the other suggestions in that repo, with elasticache.  But none of them seem applicable to us.

Did find the `clusterRetryStrategy` option - which I set the same as `retryStrategy` to prevent redis-cluster disconnects from retrying forever by default.  (In lambdas, better to just give up after a few retries and let the kinesis-retry-logic take over).

I also ended up fixing the tests to work with both cluster and non-cluster redis.  Though in CI, they only run against non-cluster.  (Setting up a redis cluster locally is non-trivial ... I've been using [docker-redis-cluster](https://github.com/Grokzen/docker-redis-cluster)).