### PR TITLE
Decode incoming digests

### DIFF
--- a/lib/decoder/index.js
+++ b/lib/decoder/index.js
@@ -12,8 +12,7 @@ function base64decode(str) {
   }
 }
 
-function decodeURIComponentCompletely(str, step) {
-  step = step || 1
+function decodeURIComponentCompletely(str, step = 1) {
   const decoded = decodeURIComponent(str)
   if (decoded === str || step > 10) {
     return decoded

--- a/lib/decoder/index.js
+++ b/lib/decoder/index.js
@@ -12,6 +12,16 @@ function base64decode(str) {
   }
 }
 
+function decodeURIComponentCompletely(str, step) {
+  step = step || 1
+  const decoded = decodeURIComponent(str)
+  if (decoded === str || step > 10) {
+    return decoded
+  } else {
+    return decodeURIComponentCompletely(decoded, step + 1)
+  }
+}
+
 /**
  * decode kinesis events
  */
@@ -67,6 +77,11 @@ exports.formatResults = function (bytes) {
       log.warn('Byte is missing time')
       byte.time = new Date().getTime()
     }
+
+    // depending on the source, digests (from the URL) may be url-encoded many
+    // times. but digests are url-safe, so we just decode them completely.
+    byte.digest = decodeURIComponentCompletely(byte.digest)
+
     byte.day = new Date(byte.time).toISOString().substr(0, 10)
     byte.id = `${byte.le}/${byte.day}/${byte.digest}`
 

--- a/lib/decoder/index.test.js
+++ b/lib/decoder/index.test.js
@@ -123,4 +123,21 @@ describe('decoder', () => {
     expect(results[2].time).toEqual(1537850000000)
     expect(results[2].bytes).toEqual(['4-5'])
   })
+
+  it('url-decodes digests', async () => {
+    const digest = 'the-decoded_digest'
+    const encoded = 'the%2Ddecoded%255fdig%65st'
+    const line = `1234.567\t12.34.56.78\t200\tGET\t/123/guid/${encoded}/file.mp3?le=my-le\t-\t-\t-\t999\t-\t-\n`
+    const event = {
+      Records: [
+        {
+          kinesis: { data: Buffer.from(line).toString('base64') },
+        },
+      ],
+    }
+
+    const results = await decoder.decodeEvent(event)
+    expect(results.length).toEqual(1)
+    expect(results[0].digest).toEqual(digest)
+  })
 })


### PR DESCRIPTION
Fixes #40.

The `cs-uri-stem` we receive via CloudFront realtime or standard logs may be url encoded.  (Our digests are url-safe, but that may not stop a client from encoding some character anyways).

IRL, I'm seeing things come into staging _double_ encoded.  So a CDN request for `ryan%5Ftest%2denc%6Fdings` shows up to the counts-lambda as `ryan%255Ftest%252denc%256Fdings`.  We decode that to `ryan_test-encodings` and onwards!