### PR TITLE
Handle trailing slashes

### DIFF
--- a/lib/decoder/real-time.js
+++ b/lib/decoder/real-time.js
@@ -48,10 +48,11 @@ exports.decode = async function (buffer) {
   const time = Math.round(parseFloat(data.timestamp) * 1000)
 
   // uri stem includes query params (ex: /123/<guid>/<digest>/file.mp3?le=<le>)
-  const le = url.parse(data['cs-uri-stem'], true).query.le
+  const parsed = url.parse(data['cs-uri-stem'] || '', true)
+  const le = parsed.query.le
 
-  // but digest is always 2nd to last
-  const digest = (data['cs-uri-stem'] || '').split('/').slice(-2, -1)[0]
+  // but digest is always 2nd to last (trimming trailing slashes)
+  const digest = parsed.pathname.replace(/\/+$/, '').split('/').slice(-2, -1)[0]
   if (!time || !le || !digest) {
     return null
   }

--- a/lib/decoder/real-time.test.js
+++ b/lib/decoder/real-time.test.js
@@ -47,6 +47,17 @@ describe('real-time', () => {
       })
     })
 
+    it('handles extra slashes in the uri stem', async () => {
+      line[4] = '/123/my-guid/my-digest/file.mp3/?a=b&le=my-le&c=d'
+      expect((await realTime.decode(line.join('\t'))).digest).toEqual('my-digest')
+
+      line[4] = '/123/my-guid/my-digest/file.mp3?a=b&le=my/-le&c=d'
+      expect((await realTime.decode(line.join('\t'))).digest).toEqual('my-digest')
+
+      line[4] = '/123/my-guid/my-digest/file.mp3?a=b&le=my-le&c=d/'
+      expect((await realTime.decode(line.join('\t'))).digest).toEqual('my-digest')
+    })
+
     it('infers byte ranges', async () => {
       line[8] = '9999'
       line[9] = '-'

--- a/lib/decoder/standard.js
+++ b/lib/decoder/standard.js
@@ -74,7 +74,7 @@ exports.decode = async function (buffer) {
   const le = url.parse('?' + (data['cs-uri-query'] || ''), true).query.le
 
   // uri stem does not include query params (ex: /123/<guid>/<digest>/file.mp3)
-  const digest = (data['cs-uri-stem'] || '').split('/').slice(-2, -1)[0]
+  const digest = (data['cs-uri-stem'] || '').replace(/\/+$/, '').split('/').slice(-2, -1)[0]
   if (!time || !le || !digest) {
     return null
   }

--- a/lib/decoder/standard.test.js
+++ b/lib/decoder/standard.test.js
@@ -74,6 +74,14 @@ describe('standard', () => {
       })
     })
 
+    it('handles extra slashes in the uri stem', async () => {
+      line[7] = '/123/my-guid/my-digest/file.mp3/'
+      expect((await standard.decode(line.join('\t'))).digest).toEqual('my-digest')
+
+      line[7] = '/123/my-guid/my-digest/file.mp3//'
+      expect((await standard.decode(line.join('\t'))).digest).toEqual('my-digest')
+    })
+
     it('infers byte ranges', async () => {
       line[30] = '9999'
       line[31] = '-'

--- a/yarn.lock
+++ b/yarn.lock
@@ -909,9 +909,9 @@ camelcase@^6.0.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001332"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz"
-  integrity sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==
+  version "1.0.30001458"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001458.tgz"
+  integrity sha512-lQ1VlUUq5q9ro9X+5gOEyH7i3vm+AYVT1WDCVB69XOZ17KZRhnZ9J0Sqz7wTHQaLBJccNCHq8/Ww5LlOIZbB0w==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Pretty sure this is the ops-fatal alarm from last night.

If a user, for some reason, adds a slash to the dovetail-cdn redirect location, they may get a 200 but the CloudFront logs end with a slash.  Causing this codebase to mis-detect the digest, and halt kinesis.