### PR TITLE
Zero byte segments

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,10 +95,15 @@ exports.handler = async event => {
         // check which segments have been FULLY downloaded
         arr.segments.forEach(([firstByte, lastByte], idx) => {
           if (arr.isLoggable(idx)) {
+            const rec = { ...bytesData, segment: idx }
+
+            // handle empty/zero-byte segments - just make sure their "firstByte" was downloaded
             if (firstByte > lastByte) {
-              kinesisRecords.push({ ...bytesData, segment: idx, isDuplicate: true, cause: 'empty' })
+              if (range.complete(firstByte, firstByte)) {
+                kinesisRecords.push({ ...rec, isDuplicate: true, cause: 'empty' })
+              }
             } else if (range.complete(firstByte, lastByte)) {
-              kinesisRecords.push({ ...bytesData, segment: idx })
+              kinesisRecords.push(rec)
             }
           }
         })

--- a/index.js
+++ b/index.js
@@ -94,8 +94,12 @@ exports.handler = async event => {
 
         // check which segments have been FULLY downloaded
         arr.segments.forEach(([firstByte, lastByte], idx) => {
-          if (arr.isLoggable(idx) && range.complete(firstByte, lastByte)) {
-            kinesisRecords.push({ ...bytesData, segment: idx })
+          if (arr.isLoggable(idx)) {
+            if (firstByte > lastByte) {
+              kinesisRecords.push({ ...bytesData, segment: idx, isDuplicate: true, cause: 'empty' })
+            } else if (range.complete(firstByte, lastByte)) {
+              kinesisRecords.push({ ...bytesData, segment: idx })
+            }
           }
         })
       }),

--- a/index.test.js
+++ b/index.test.js
@@ -207,6 +207,26 @@ describe('handler', () => {
     expect(kinesis.__records[6]).toMatchObject({ type: 'segmentbytes', segment: 6 })
   })
 
+  it('does not count empty segments', async () => {
+    dynamo.__addArrangement('itest-digest', {
+      version: 4,
+      data: { t: 'oaaao', b: [1, 2, 3, 3, 4, 5], a: [128, 1, 44100] },
+    })
+    decoder.__addBytes({ le: 'itest1', digest: 'itest-digest', time: 1, start: 0, end: 5 })
+
+    expect(await handler()).toMatchObject({ overall: 1, segments: 2 })
+    expect(kinesis.__records.length).toEqual(4)
+    expect(kinesis.__records[0]).toMatchObject({ type: 'bytes' })
+    expect(kinesis.__records[1]).toMatchObject({ type: 'segmentbytes', segment: 1 })
+    expect(kinesis.__records[2]).toMatchObject({
+      type: 'segmentbytes',
+      segment: 2,
+      isDuplicate: true,
+      cause: 'empty',
+    })
+    expect(kinesis.__records[3]).toMatchObject({ type: 'segmentbytes', segment: 3 })
+  })
+
   it('allows dynamodb arrangements', async () => {
     jest.spyOn(log, 'warn').mockImplementation(() => null)
 

--- a/index.test.js
+++ b/index.test.js
@@ -207,24 +207,29 @@ describe('handler', () => {
     expect(kinesis.__records[6]).toMatchObject({ type: 'segmentbytes', segment: 6 })
   })
 
-  it('does not count empty segments', async () => {
+  it.only('does not count empty segments', async () => {
     dynamo.__addArrangement('itest-digest', {
       version: 4,
       data: { t: 'oaaao', b: [1, 2, 3, 3, 4, 5], a: [128, 1, 44100] },
     })
-    decoder.__addBytes({ le: 'itest1', digest: 'itest-digest', time: 1, start: 0, end: 5 })
 
-    expect(await handler()).toMatchObject({ overall: 1, segments: 2 })
-    expect(kinesis.__records.length).toEqual(4)
-    expect(kinesis.__records[0]).toMatchObject({ type: 'bytes' })
-    expect(kinesis.__records[1]).toMatchObject({ type: 'segmentbytes', segment: 1 })
-    expect(kinesis.__records[2]).toMatchObject({
+    // download just first ad
+    decoder.__addBytes({ le: 'itest1', digest: 'itest-digest', time: 1, start: 0, end: 2 })
+    expect(await handler()).toMatchObject({ overall: 0, segments: 1 })
+    expect(kinesis.__records.length).toEqual(1)
+    expect(kinesis.__records[0]).toMatchObject({ type: 'segmentbytes', segment: 1 })
+
+    // download next byte, triggering segments 2 and 3
+    decoder.__addBytes({ le: 'itest1', digest: 'itest-digest', time: 1, start: 0, end: 3 })
+    expect(await handler()).toMatchObject({ overall: 0, segments: 1 })
+    expect(kinesis.__records.length).toEqual(3)
+    expect(kinesis.__records[1]).toMatchObject({
       type: 'segmentbytes',
       segment: 2,
       isDuplicate: true,
       cause: 'empty',
     })
-    expect(kinesis.__records[3]).toMatchObject({ type: 'segmentbytes', segment: 3 })
+    expect(kinesis.__records[2]).toMatchObject({ type: 'segmentbytes', segment: 3 })
   })
 
   it('allows dynamodb arrangements', async () => {

--- a/lib/arrangement.js
+++ b/lib/arrangement.js
@@ -9,6 +9,7 @@ const dynamo = require('./dynamo')
 const { promiseAnyTruthy } = require('./util')
 
 const DEFAULT_TTL = 86400
+const DEFAULT_INCOMPLETE_TTL = 300
 const DEFAULT_BITRATE = 128000
 const MEMOIZED = {}
 
@@ -67,7 +68,13 @@ module.exports = class Arrangement {
       const uncached = await dynamo.getArrangement(digest, ddbClient)
       if (uncached) {
         const arr = new Arrangement(digest, uncached)
-        const ttl = process.env.REDIS_ARRANGEMENT_TTL || DEFAULT_TTL
+
+        // shorter ttl for incomplete arrangements, in case we later re-stitch and get all files
+        let ttl = process.env.REDIS_ARRANGEMENT_TTL || DEFAULT_TTL
+        if (uncached.incomplete) {
+          ttl = process.env.REDIS_ARRANGEMENT_INCOMPLETE_TTL || DEFAULT_INCOMPLETE_TTL
+        }
+
         await redis.setex(`dtcounts:ddb:${digest}`, ttl, arr.encode())
         return arr
       } else {

--- a/lib/arrangement.test.js
+++ b/lib/arrangement.test.js
@@ -46,6 +46,15 @@ describe('arrangement', () => {
     const json = await redis.get(KEY)
     expect(json).not.toBeNull()
     expect(json).toEqual(arr.encode())
+    expect(await redis.ttl(KEY)).toBeGreaterThan(10000)
+  })
+
+  it('uses a shorter ttl for incomplete arrangements', async () => {
+    dynamo.__addArrangement(DIGEST, { ...mockData, incomplete: 1 })
+    expect(await redis.get(KEY)).toBeNull()
+
+    const arr = await Arrangement.load(DIGEST, redis)
+    expect(await redis.ttl(KEY)).toBeLessThan(1000)
   })
 
   it('memoizes requests for the same arrangement', async () => {

--- a/lib/kinesis.js
+++ b/lib/kinesis.js
@@ -16,11 +16,25 @@ exports._putRecords = opts => kinesis.putRecords(opts).promise()
 /**
  * Formatted kinesis impression records
  */
-exports.format = function ({ time, le, digest, segment, bytes, seconds, percent }) {
+exports.format = function ({
+  time,
+  le,
+  digest,
+  segment,
+  bytes,
+  seconds,
+  percent,
+  isDuplicate,
+  cause,
+}) {
   let rec = {
     timestamp: time || new Date().getTime(),
     listenerEpisode: le,
     digest: digest,
+  }
+  if (isDuplicate) {
+    rec.isDuplicate = true
+    rec.cause = cause
   }
   if (segment === undefined) {
     rec.type = 'bytes'

--- a/yarn.lock
+++ b/yarn.lock
@@ -909,9 +909,9 @@ camelcase@^6.0.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001458"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001458.tgz"
-  integrity sha512-lQ1VlUUq5q9ro9X+5gOEyH7i3vm+AYVT1WDCVB69XOZ17KZRhnZ9J0Sqz7wTHQaLBJccNCHq8/Ww5LlOIZbB0w==
+  version "1.0.30001591"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001591.tgz"
+  integrity sha512-PCzRMei/vXjJyL5mJtzNiUCKP59dm8Apqc3PH8gJkMnMXZGox93RbE76jHsmLwmIo6/3nsYIpJtx0O7u5PqFuQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
For https://github.com/PRX/dovetail-cdn-arranger/issues/32

This needs to deploy before https://github.com/PRX/dovetail-cdn-arranger/pull/33

Logs a `type: "segmentbytes"` record (with `cause: "empty"`) to kinesis for 0 byte files.

Also only caches "incomplete" arrangement JSON in redis (pulling from DDB) for 5 minutes.  Vs the usual 1-day.