### PR TITLE
Impressions part of valid download

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,8 @@ exports.handler = async event => {
         const total = bytesDownloaded.reduce((a, b) => a + b, 0)
         const totalSeconds = arr.bytesToSeconds(total)
         const totalPercent = arr.bytesToPercent(total)
-        if (totalSeconds >= minSeconds || totalPercent >= minPercent) {
+        const isDownload = totalSeconds >= minSeconds || totalPercent >= minPercent
+        if (isDownload) {
           kinesisRecords.push({
             ...bytesData,
             bytes: total,
@@ -94,7 +95,7 @@ exports.handler = async event => {
 
         // check which segments have been FULLY downloaded
         arr.segments.forEach(([firstByte, lastByte], idx) => {
-          if (arr.isLoggable(idx)) {
+          if (isDownload && arr.isLoggable(idx)) {
             const rec = { ...bytesData, segment: idx }
 
             // handle empty/zero-byte segments - just make sure their "firstByte" was downloaded

--- a/yarn.lock
+++ b/yarn.lock
@@ -909,9 +909,9 @@ camelcase@^6.0.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001591"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001591.tgz"
-  integrity sha512-PCzRMei/vXjJyL5mJtzNiUCKP59dm8Apqc3PH8gJkMnMXZGox93RbE76jHsmLwmIo6/3nsYIpJtx0O7u5PqFuQ==
+  version "1.0.30001667"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001667.tgz"
+  integrity sha512-7LTwJjcRkzKFmtqGsibMeuXmvFDfZq/nzIjnmgCGzKKRVzjD72selLDK1oPF/Oxzmt4fNcPvTDvGqSDG4tCALw==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes #48.

Check if a file has been "overall downloaded" (1 minute of audio or all of the bytes) before logging an impression for any ad segments.

Dug through BigQuery a bit - it appears this will impact about 0.039% of our impressions.  (That's 4/100ths of 1 percent, not 4%).