### PR TITLE
Ad load metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ The `KINESIS_IMPRESSION_STREAM` is the main output of this function. These shoul
   "bytes": 9999,
   "seconds": 1.84,
   "percent": 0.65,
+  "percentAds": 0.0684,
   "isDuplicate": true,
   "cause": "digestCache"
 }
@@ -163,6 +164,8 @@ or
   "listenerEpisode": "some-listener-episode",
   "digest": "the-arrangement-digest",
   "segment": 3,
+  "segmentPosition": 0,
+  "percentAds": 0.0684,
   "isDuplicate": true,
   "cause": "digestCache"
 }
@@ -184,4 +187,3 @@ Or to use docker, just run `docker-compose build` and `docker-compose run test`.
 # License
 
 [AGPL License](https://www.gnu.org/licenses/agpl-3.0.html)
-

--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ exports.handler = async event => {
       readyBytes.map(async bytesData => {
         const range = await ByteRange.load(bytesData.id, redis, bytesData.bytes)
         const arr = digests[bytesData.digest]
+        const ads = arr.percentAds
 
         // check if the file-as-a-whole has been downloaded
         const bytesDownloaded = arr.segments.map(s => range.intersect(s))
@@ -90,13 +91,15 @@ exports.handler = async event => {
             bytes: total,
             seconds: totalSeconds,
             percent: totalPercent,
+            percentAds: ads,
           })
         }
 
         // check which segments have been FULLY downloaded
         arr.segments.forEach(([firstByte, lastByte], idx) => {
           if (isDownload && arr.isLoggable(idx)) {
-            const rec = { ...bytesData, segment: idx }
+            const pos = arr.segmentPosition(idx)
+            const rec = { ...bytesData, segment: idx, segmentPosition: pos, percentAds: ads }
 
             // handle empty/zero-byte segments - just make sure their "firstByte" was downloaded
             if (firstByte > lastByte) {

--- a/index.test.js
+++ b/index.test.js
@@ -60,9 +60,19 @@ describe('handler', () => {
 
     expect(await handler()).toMatchObject({ overall: 1, segments: 2 })
     expect(kinesis.__records.length).toEqual(3)
-    expect(kinesis.__records[0]).toMatchObject({ type: 'bytes' })
-    expect(kinesis.__records[1]).toMatchObject({ type: 'segmentbytes', segment: 1 })
-    expect(kinesis.__records[2]).toMatchObject({ type: 'segmentbytes', segment: 3 })
+    expect(kinesis.__records[0]).toMatchObject({ type: 'bytes', percentAds: 0.0208 })
+    expect(kinesis.__records[1]).toMatchObject({
+      type: 'segmentbytes',
+      percentAds: 0.0208,
+      segment: 1,
+      segmentPosition: 0,
+    })
+    expect(kinesis.__records[2]).toMatchObject({
+      type: 'segmentbytes',
+      percentAds: 0.0208,
+      segment: 3,
+      segmentPosition: 0,
+    })
   })
 
   it('records empty downloads', async () => {
@@ -106,6 +116,7 @@ describe('handler', () => {
       bytes: 100,
       seconds: 10,
       percent: 0.5,
+      percentAds: 0,
     })
   })
 
@@ -136,6 +147,7 @@ describe('handler', () => {
       bytes: 311,
       seconds: 3.11,
       percent: 0.7775,
+      percentAds: 0.25,
     })
   })
 
@@ -200,6 +212,8 @@ describe('handler', () => {
       digest: 'itest-digest',
       segment: 1,
       timestamp: 1,
+      percentAds: 0.0513,
+      segmentPosition: 1,
     })
   })
 

--- a/lib/arrangement.js
+++ b/lib/arrangement.js
@@ -103,6 +103,19 @@ module.exports = class Arrangement {
     }
   }
 
+  get percentAds() {
+    let adBytes = 0
+    let totalBytes = this.segmentSize()
+
+    this.types.split('').forEach((type, idx) => {
+      if (type !== 'o' && type !== 'i') {
+        adBytes += this.segmentSize(idx)
+      }
+    })
+
+    return totalBytes ? adBytes / totalBytes : 0
+  }
+
   // log all non-original segments
   isLoggable(idx) {
     return !!this.types[idx] && this.types[idx] !== 'o'

--- a/lib/arrangement.js
+++ b/lib/arrangement.js
@@ -148,6 +148,15 @@ module.exports = class Arrangement {
     }
   }
 
+  segmentPosition(idx) {
+    if (this.types[idx] === 'o') {
+      return null
+    }
+    const prevTypes = this.types.substr(0, idx)
+    const prevAds = prevTypes.split('o').pop()
+    return prevAds.length
+  }
+
   bytesToSeconds(numBytes) {
     return numBytes / (this.bitrate / 8)
   }

--- a/lib/arrangement.test.js
+++ b/lib/arrangement.test.js
@@ -206,6 +206,23 @@ describe('arrangement', () => {
     expect(arr.segmentSize()).toEqual(30)
   })
 
+  it('calculates segment positions', () => {
+    const t = 'aoaahoohi'
+    const b = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    const a = { f: 'mp3', b: 130, c: 1, s: 44100 }
+    const arr = new Arrangement(DIGEST, { version: 4, data: { t, b, a } })
+
+    expect(arr.segmentPosition(0)).toEqual(0)
+    expect(arr.segmentPosition(1)).toEqual(null)
+    expect(arr.segmentPosition(2)).toEqual(0)
+    expect(arr.segmentPosition(3)).toEqual(1)
+    expect(arr.segmentPosition(4)).toEqual(2)
+    expect(arr.segmentPosition(5)).toEqual(null)
+    expect(arr.segmentPosition(6)).toEqual(null)
+    expect(arr.segmentPosition(7)).toEqual(0)
+    expect(arr.segmentPosition(8)).toEqual(1)
+  })
+
   it('converts bytes to seconds', () => {
     const arr = new Arrangement(DIGEST, { version: 3, data: { t: 'ooo', b: [10, 20, 30, 40] } })
 

--- a/lib/arrangement.test.js
+++ b/lib/arrangement.test.js
@@ -177,6 +177,18 @@ describe('arrangement', () => {
     expect(warns.length).toEqual(0)
   })
 
+  it('calculates the percentage of ads', () => {
+    const t = 'aoaohi'
+    const b = [100, 200, 1900, 2000, 2900, 3000, 3100]
+    const a = { f: 'mp3', b: 130, c: 1, s: 44100 }
+    const arr = new Arrangement(DIGEST, { version: 4, data: { t, b, a } })
+
+    expect(arr.segmentSize()).toEqual(3000)
+    expect([0, 2, 4].map(i => arr.segmentSize(i))).toEqual([100, 100, 100])
+    expect([1, 3, 5].map(i => arr.segmentSize(i))).toEqual([1700, 900, 100])
+    expect(arr.percentAds).toEqual(300 / 3000)
+  })
+
   it('calculates segment ranges', () => {
     const arr = new Arrangement(DIGEST, { version: 3, data: { t: 'ooo', b: [10, 20, 30, 40] } })
     expect(arr.segments.length).toEqual(3)

--- a/lib/kinesis.js
+++ b/lib/kinesis.js
@@ -21,9 +21,11 @@ exports.format = function ({
   le,
   digest,
   segment,
+  segmentPosition,
   bytes,
   seconds,
   percent,
+  percentAds,
   isDuplicate,
   cause,
 }) {
@@ -41,9 +43,12 @@ exports.format = function ({
     rec.bytes = bytes
     rec.seconds = round(seconds, 2)
     rec.percent = round(percent, 4)
+    rec.percentAds = round(percentAds, 4)
   } else {
     rec.type = 'segmentbytes'
     rec.segment = segment
+    rec.segmentPosition = segmentPosition
+    rec.percentAds = round(percentAds, 4)
   }
   return rec
 }

--- a/lib/kinesis.test.js
+++ b/lib/kinesis.test.js
@@ -4,12 +4,11 @@ const lock = require('./kinesis-lock')
 const RedisBackup = require('./redis-backup')
 
 describe('kinesis', () => {
-
   let redis, overall, segment
   beforeEach(() => {
     redis = new RedisBackup(process.env.REDIS_URL)
-    overall = {le: '1234', digest: '5678', time: 9, bytes: 10, seconds: 12, percent: 0.4}
-    segment = {...overall, segment: 2}
+    overall = { le: '1234', digest: '5678', time: 9, bytes: 10, seconds: 12, percent: 0.4 }
+    segment = { ...overall, segment: 2 }
     process.env.KINESIS_IMPRESSION_STREAM = 'some-good-stream'
   })
 
@@ -22,19 +21,22 @@ describe('kinesis', () => {
 
   // mock each kinesis.putRecords() batch call, and success/failure statuses
   function mockPutRecords(...isSuccessList) {
-    let idx = 0, calls = []
-    jest.spyOn(kinesis, '_putRecords').mockImplementation(async function(args) {
+    let idx = 0,
+      calls = []
+    jest.spyOn(kinesis, '_putRecords').mockImplementation(async function (args) {
       calls.push(args)
-      return {Records: args.Records.map(() => {
-        const isSuccess = isSuccessList[idx++]
-        if (isSuccess === true) {
-          return {SequenceNumber: 'anything', ShardId: 'anything'}
-        } else if (isSuccess === false) {
-          return {ErrorCode: 'anything', ErrorMessage: 'anything'}
-        } else {
-          throw new Error(`Unmocked kinesis result ${idx}`)
-        }
-      })}
+      return {
+        Records: args.Records.map(() => {
+          const isSuccess = isSuccessList[idx++]
+          if (isSuccess === true) {
+            return { SequenceNumber: 'anything', ShardId: 'anything' }
+          } else if (isSuccess === false) {
+            return { ErrorCode: 'anything', ErrorMessage: 'anything' }
+          } else {
+            throw new Error(`Unmocked kinesis result ${idx}`)
+          }
+        }),
+      }
     })
     return calls
   }
@@ -52,7 +54,7 @@ describe('kinesis', () => {
       timestamp: 9,
       bytes: 10,
       seconds: 12,
-      percent: 0.4
+      percent: 0.4,
     })
   })
 
@@ -62,14 +64,14 @@ describe('kinesis', () => {
       segment: 2,
       listenerEpisode: '1234',
       digest: '5678',
-      timestamp: 9
+      timestamp: 9,
     })
   })
 
   it('rounds seconds and percents', () => {
-    expect(kinesis.format({...overall, seconds: 0.123456, percent: 0.123456})).toMatchObject({
+    expect(kinesis.format({ ...overall, seconds: 0.123456, percent: 0.123456 })).toMatchObject({
       seconds: 0.12,
-      percent: 0.1235
+      percent: 0.1235,
     })
   })
 
@@ -85,12 +87,15 @@ describe('kinesis', () => {
   })
 
   it('puts nothing', async () => {
-    expect(await kinesis.putWithLock(redis, [])).toMatchObject({overall: 0, segments: 0})
+    expect(await kinesis.putWithLock(redis, [])).toMatchObject({ overall: 0, segments: 0 })
   })
 
   it('puts formatted records to kinesis', async () => {
     const calls = mockPutRecords(true, true)
-    expect(await kinesis.putWithLock(redis, [overall, segment])).toMatchObject({overall: 1, segments: 1})
+    expect(await kinesis.putWithLock(redis, [overall, segment])).toMatchObject({
+      overall: 1,
+      segments: 1,
+    })
     expect(calls.length).toEqual(1)
     expect(calls[0].StreamName).toEqual('some-good-stream')
     expect(calls[0].Records.length).toEqual(2)
@@ -103,9 +108,11 @@ describe('kinesis', () => {
   it('only puts an overall download once', async () => {
     const calls = mockPutRecords(true)
     expect(await isLocked(overall)).toEqual(false)
-    expect(await kinesis.putWithLock(redis, [overall, overall, overall])).toMatchObject({overall: 1})
-    expect(await kinesis.putWithLock(redis, [overall])).toMatchObject({overall: 0})
-    expect(await kinesis.putWithLock(redis, [overall, overall])).toMatchObject({overall: 0})
+    expect(await kinesis.putWithLock(redis, [overall, overall, overall])).toMatchObject({
+      overall: 1,
+    })
+    expect(await kinesis.putWithLock(redis, [overall])).toMatchObject({ overall: 0 })
+    expect(await kinesis.putWithLock(redis, [overall, overall])).toMatchObject({ overall: 0 })
     expect(calls.length).toEqual(1)
     expect(calls[0].Records.length).toEqual(1)
     expect(await isLocked(overall)).toEqual(true)
@@ -114,9 +121,11 @@ describe('kinesis', () => {
   it('only puts a segment impression once', async () => {
     const calls = mockPutRecords(true)
     expect(await isLocked(segment)).toEqual(false)
-    expect(await kinesis.putWithLock(redis, [segment, segment])).toMatchObject({segments: 1})
-    expect(await kinesis.putWithLock(redis, [segment, segment, segment])).toMatchObject({segments: 0})
-    expect(await kinesis.putWithLock(redis, [segment])).toMatchObject({segments: 0})
+    expect(await kinesis.putWithLock(redis, [segment, segment])).toMatchObject({ segments: 1 })
+    expect(await kinesis.putWithLock(redis, [segment, segment, segment])).toMatchObject({
+      segments: 0,
+    })
+    expect(await kinesis.putWithLock(redis, [segment])).toMatchObject({ segments: 0 })
     expect(calls.length).toEqual(1)
     expect(calls[0].Records.length).toEqual(1)
     expect(await isLocked(segment)).toEqual(true)
@@ -126,15 +135,18 @@ describe('kinesis', () => {
     const calls = mockPutRecords(false, true, true)
 
     jest.spyOn(log, 'warn').mockImplementation(() => null)
-    expect(await kinesis.putWithLock(redis, [overall, segment])).toMatchObject({segments: 1, failed: 1})
+    expect(await kinesis.putWithLock(redis, [overall, segment])).toMatchObject({
+      segments: 1,
+      failed: 1,
+    })
     expect(await isLocked(overall)).toEqual(false)
     expect(await isLocked(segment)).toEqual(true)
 
     expect(log.warn).toHaveBeenCalledTimes(1)
     expect(log.warn.mock.calls[0][0].message).toMatch('putRecords partial failure')
-    expect(log.warn.mock.calls[0][1]).toMatchObject({ErrorCode: 'anything'})
+    expect(log.warn.mock.calls[0][1]).toMatchObject({ ErrorCode: 'anything' })
 
-    expect(await kinesis.putWithLock(redis, [overall, segment])).toMatchObject({overall: 1})
+    expect(await kinesis.putWithLock(redis, [overall, segment])).toMatchObject({ overall: 1 })
     expect(calls.length).toEqual(2)
     expect(calls[0].Records.length).toEqual(2) // overall=failed, segment=success
     expect(calls[1].Records.length).toEqual(1) // overall=success
@@ -148,7 +160,7 @@ describe('kinesis', () => {
     })
 
     jest.spyOn(log, 'warn').mockImplementation(() => null)
-    expect(await kinesis.putWithLock(redis, [overall])).toMatchObject({failed: 1})
+    expect(await kinesis.putWithLock(redis, [overall])).toMatchObject({ failed: 1 })
     expect(await isLocked(overall)).toEqual(false)
 
     expect(log.warn).toHaveBeenCalledTimes(1)
@@ -158,8 +170,10 @@ describe('kinesis', () => {
 
   it('locks to the first digest downloaded', async () => {
     const calls = mockPutRecords(true, true)
-    expect(await kinesis.putWithLock(redis, [overall])).toMatchObject({overall: 1})
-    expect(await kinesis.putWithLock(redis, [{...overall, digest: '5679'}])).toMatchObject({overallDups: 1})
+    expect(await kinesis.putWithLock(redis, [overall])).toMatchObject({ overall: 1 })
+    expect(await kinesis.putWithLock(redis, [{ ...overall, digest: '5679' }])).toMatchObject({
+      overallDups: 1,
+    })
     expect(calls.length).toEqual(2)
     expect(calls[0].Records.length).toEqual(1)
     expect(JSON.parse(calls[0].Records[0].Data).isDuplicate).toBeUndefined()
@@ -172,9 +186,11 @@ describe('kinesis', () => {
     const calls = mockPutRecords(false, true)
 
     jest.spyOn(log, 'warn').mockImplementation(() => null)
-    expect(await kinesis.putWithLock(redis, [segment])).toMatchObject({failed: 1})
+    expect(await kinesis.putWithLock(redis, [segment])).toMatchObject({ failed: 1 })
 
-    expect(await kinesis.putWithLock(redis, [{...segment, digest: '5679'}])).toMatchObject({segmentDups: 1})
+    expect(await kinesis.putWithLock(redis, [{ ...segment, digest: '5679' }])).toMatchObject({
+      segmentDups: 1,
+    })
     expect(calls.length).toEqual(2)
     expect(calls[1].Records.length).toEqual(1)
     expect(JSON.parse(calls[1].Records[0].Data).isDuplicate).toEqual(true)
@@ -184,9 +200,13 @@ describe('kinesis', () => {
   it('splits into batches', async () => {
     const calls = mockPutRecords(true, true, true, true)
     const manyRecords = [
-      overall, overall, overall,
-      segment, overall, {...segment, le: '1235'},
-      {...overall, le: '1235'}
+      overall,
+      overall,
+      overall,
+      segment,
+      overall,
+      { ...segment, le: '1235' },
+      { ...overall, le: '1235' },
     ]
 
     expect(await kinesis.putWithLock(redis, manyRecords, 3)).toMatchObject({
@@ -194,17 +214,16 @@ describe('kinesis', () => {
       overallDups: 0,
       segments: 2,
       segmentDups: 0,
-      failed: 0
+      failed: 0,
     })
     expect(calls.length).toEqual(3)
 
     // order of locks not guaranteed - but groupings are
     const keys = calls.map(c => c.Records.map(r => r.PartitionKey))
-    const sorted = keys.sort((a, b) => JSON.stringify(a) < JSON.stringify(b) ? 1 : -1)
+    const sorted = keys.sort((a, b) => (JSON.stringify(a) < JSON.stringify(b) ? 1 : -1))
 
     expect(sorted[0]).toEqual(['1235'])
     expect(sorted[1]).toEqual(['1234'])
     expect(sorted[2]).toEqual(['1234', '1235'])
   })
-
 })

--- a/lib/kinesis.test.js
+++ b/lib/kinesis.test.js
@@ -7,8 +7,16 @@ describe('kinesis', () => {
   let redis, overall, segment
   beforeEach(() => {
     redis = new RedisBackup(process.env.REDIS_URL)
-    overall = { le: '1234', digest: '5678', time: 9, bytes: 10, seconds: 12, percent: 0.4 }
-    segment = { ...overall, segment: 2 }
+    overall = {
+      le: '1234',
+      digest: '5678',
+      time: 9,
+      bytes: 10,
+      seconds: 12,
+      percent: 0.4,
+      percentAds: 0.1,
+    }
+    segment = { ...overall, segment: 2, segmentPosition: 1, percentAds: 0.1 }
     process.env.KINESIS_IMPRESSION_STREAM = 'some-good-stream'
   })
 
@@ -55,6 +63,7 @@ describe('kinesis', () => {
       bytes: 10,
       seconds: 12,
       percent: 0.4,
+      percentAds: 0.1,
     })
   })
 
@@ -62,6 +71,8 @@ describe('kinesis', () => {
     expect(kinesis.format(segment)).toEqual({
       type: 'segmentbytes',
       segment: 2,
+      segmentPosition: 1,
+      percentAds: 0.1,
       listenerEpisode: '1234',
       digest: '5678',
       timestamp: 9,


### PR DESCRIPTION
Starting on https://github.com/PRX/dovetail-router.prx.org/issues/343.

1. Add `percentAds` to both `bytes` and `segmentbytes` kinesis records.
2. Add `segmentPosition` to `segmentbytes` kinesis records.