### PR TITLE
Arrangement structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ The `KINESIS_IMPRESSION_STREAM` is the main output of this function. These shoul
   "bytes": 9999,
   "seconds": 1.84,
   "percent": 0.65,
-  "percentAds": 0.0684,
   "isDuplicate": true,
   "cause": "digestCache"
 }
@@ -164,8 +163,6 @@ or
   "listenerEpisode": "some-listener-episode",
   "digest": "the-arrangement-digest",
   "segment": 3,
-  "segmentPosition": 0,
-  "percentAds": 0.0684,
   "isDuplicate": true,
   "cause": "digestCache"
 }

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ The `KINESIS_IMPRESSION_STREAM` is the main output of this function. These shoul
   "bytes": 9999,
   "seconds": 1.84,
   "percent": 0.65,
+  "durations": [12.85924, 948.9482285, 1.5846666666],
+  "types": "aoi",
   "isDuplicate": true,
   "cause": "digestCache"
 }

--- a/index.js
+++ b/index.js
@@ -77,7 +77,6 @@ exports.handler = async event => {
       readyBytes.map(async bytesData => {
         const range = await ByteRange.load(bytesData.id, redis, bytesData.bytes)
         const arr = digests[bytesData.digest]
-        const ads = arr.percentAds
 
         // check if the file-as-a-whole has been downloaded
         const bytesDownloaded = arr.segments.map(s => range.intersect(s))
@@ -91,15 +90,13 @@ exports.handler = async event => {
             bytes: total,
             seconds: totalSeconds,
             percent: totalPercent,
-            percentAds: ads,
           })
         }
 
         // check which segments have been FULLY downloaded
         arr.segments.forEach(([firstByte, lastByte], idx) => {
           if (isDownload && arr.isLoggable(idx)) {
-            const pos = arr.segmentPosition(idx)
-            const rec = { ...bytesData, segment: idx, segmentPosition: pos, percentAds: ads }
+            const rec = { ...bytesData, segment: idx }
 
             // handle empty/zero-byte segments - just make sure their "firstByte" was downloaded
             if (firstByte > lastByte) {

--- a/index.js
+++ b/index.js
@@ -90,6 +90,8 @@ exports.handler = async event => {
             bytes: total,
             seconds: totalSeconds,
             percent: totalPercent,
+            durations: arr.durations(),
+            types: arr.types,
           })
         }
 

--- a/index.test.js
+++ b/index.test.js
@@ -157,7 +157,7 @@ describe('handler', () => {
     expect(kinesis.__records[0]).toMatchObject({ type: 'bytes' })
   })
 
-  it('does not count segments until they are fully downloaded', async () => {
+  it.only('does not count segments until they are fully downloaded', async () => {
     dynamo.__addArrangement('itest-digest', {
       version: 4,
       data: { t: 'aao', b: [100, 200, 300, 4000], a: [128, 1, 44100] },
@@ -193,6 +193,8 @@ describe('handler', () => {
       listenerEpisode: 'itest1',
       digest: 'itest-digest',
       timestamp: 1,
+      durations: [0.00625, 0.00625, 0.23125],
+      types: 'aao',
     })
     expect(kinesis.__records[1]).toEqual({
       type: 'segmentbytes',

--- a/index.test.js
+++ b/index.test.js
@@ -60,19 +60,9 @@ describe('handler', () => {
 
     expect(await handler()).toMatchObject({ overall: 1, segments: 2 })
     expect(kinesis.__records.length).toEqual(3)
-    expect(kinesis.__records[0]).toMatchObject({ type: 'bytes', percentAds: 0.0208 })
-    expect(kinesis.__records[1]).toMatchObject({
-      type: 'segmentbytes',
-      percentAds: 0.0208,
-      segment: 1,
-      segmentPosition: 0,
-    })
-    expect(kinesis.__records[2]).toMatchObject({
-      type: 'segmentbytes',
-      percentAds: 0.0208,
-      segment: 3,
-      segmentPosition: 0,
-    })
+    expect(kinesis.__records[0]).toMatchObject({ type: 'bytes' })
+    expect(kinesis.__records[1]).toMatchObject({ type: 'segmentbytes', segment: 1 })
+    expect(kinesis.__records[2]).toMatchObject({ type: 'segmentbytes', segment: 3 })
   })
 
   it('records empty downloads', async () => {
@@ -116,7 +106,6 @@ describe('handler', () => {
       bytes: 100,
       seconds: 10,
       percent: 0.5,
-      percentAds: 0,
     })
   })
 
@@ -147,7 +136,6 @@ describe('handler', () => {
       bytes: 311,
       seconds: 3.11,
       percent: 0.7775,
-      percentAds: 0.25,
     })
   })
 
@@ -212,8 +200,6 @@ describe('handler', () => {
       digest: 'itest-digest',
       segment: 1,
       timestamp: 1,
-      percentAds: 0.0513,
-      segmentPosition: 1,
     })
   })
 

--- a/lib/arrangement.js
+++ b/lib/arrangement.js
@@ -103,19 +103,6 @@ module.exports = class Arrangement {
     }
   }
 
-  get percentAds() {
-    let adBytes = 0
-    let totalBytes = this.segmentSize()
-
-    this.types.split('').forEach((type, idx) => {
-      if (type !== 'o' && type !== 'i') {
-        adBytes += this.segmentSize(idx)
-      }
-    })
-
-    return totalBytes ? adBytes / totalBytes : 0
-  }
-
   // log all non-original segments
   isLoggable(idx) {
     return !!this.types[idx] && this.types[idx] !== 'o'
@@ -146,15 +133,6 @@ module.exports = class Arrangement {
     } else {
       return this.segments[idx][1] - this.segments[idx][0] + 1
     }
-  }
-
-  segmentPosition(idx) {
-    if (this.types[idx] === 'o') {
-      return null
-    }
-    const prevTypes = this.types.substr(0, idx)
-    const prevAds = prevTypes.split('o').pop()
-    return prevAds.length
   }
 
   bytesToSeconds(numBytes) {

--- a/lib/arrangement.js
+++ b/lib/arrangement.js
@@ -142,4 +142,10 @@ module.exports = class Arrangement {
   bytesToPercent(numBytes, segmentIdx) {
     return numBytes / this.segmentSize(segmentIdx)
   }
+
+  durations() {
+    return this.bytes.slice(0, -1).map((startByte, idx) => {
+      return this.bytesToSeconds(this.bytes[idx + 1] - startByte)
+    })
+  }
 }

--- a/lib/arrangement.test.js
+++ b/lib/arrangement.test.js
@@ -177,18 +177,6 @@ describe('arrangement', () => {
     expect(warns.length).toEqual(0)
   })
 
-  it('calculates the percentage of ads', () => {
-    const t = 'aoaohi'
-    const b = [100, 200, 1900, 2000, 2900, 3000, 3100]
-    const a = { f: 'mp3', b: 130, c: 1, s: 44100 }
-    const arr = new Arrangement(DIGEST, { version: 4, data: { t, b, a } })
-
-    expect(arr.segmentSize()).toEqual(3000)
-    expect([0, 2, 4].map(i => arr.segmentSize(i))).toEqual([100, 100, 100])
-    expect([1, 3, 5].map(i => arr.segmentSize(i))).toEqual([1700, 900, 100])
-    expect(arr.percentAds).toEqual(300 / 3000)
-  })
-
   it('calculates segment ranges', () => {
     const arr = new Arrangement(DIGEST, { version: 3, data: { t: 'ooo', b: [10, 20, 30, 40] } })
     expect(arr.segments.length).toEqual(3)
@@ -204,23 +192,6 @@ describe('arrangement', () => {
     expect(arr.segmentSize(1)).toEqual(10)
     expect(arr.segmentSize(2)).toEqual(10)
     expect(arr.segmentSize()).toEqual(30)
-  })
-
-  it('calculates segment positions', () => {
-    const t = 'aoaahoohi'
-    const b = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    const a = { f: 'mp3', b: 130, c: 1, s: 44100 }
-    const arr = new Arrangement(DIGEST, { version: 4, data: { t, b, a } })
-
-    expect(arr.segmentPosition(0)).toEqual(0)
-    expect(arr.segmentPosition(1)).toEqual(null)
-    expect(arr.segmentPosition(2)).toEqual(0)
-    expect(arr.segmentPosition(3)).toEqual(1)
-    expect(arr.segmentPosition(4)).toEqual(2)
-    expect(arr.segmentPosition(5)).toEqual(null)
-    expect(arr.segmentPosition(6)).toEqual(null)
-    expect(arr.segmentPosition(7)).toEqual(0)
-    expect(arr.segmentPosition(8)).toEqual(1)
   })
 
   it('converts bytes to seconds', () => {

--- a/lib/arrangement.test.js
+++ b/lib/arrangement.test.js
@@ -233,4 +233,20 @@ describe('arrangement', () => {
     expect(arr.isLoggable(6)).toEqual(true)
     expect(arr.isLoggable(99)).toEqual(false)
   })
+
+  it('calculates durations for the whole arrangement', () => {
+    const t = 'aaoaa'
+    const b = [15064, 371492, 730727, 20308144, 20664872, 21024107]
+    const a = { f: 'mp3', b: 192, c: 2, s: 44100 }
+    const arr = new Arrangement(DIGEST, { version: 4, data: { t, b, a } })
+
+    // known arrangement, rounded to 6 decimals
+    const dur = arr.durations()
+    expect(dur.length).toEqual(5)
+    expect(dur[0].toFixed(6)).toEqual('14.851167')
+    expect(dur[1].toFixed(6)).toEqual('14.968125')
+    expect(dur[2].toFixed(6)).toEqual('815.725708')
+    expect(dur[3].toFixed(6)).toEqual('14.863667')
+    expect(dur[4].toFixed(6)).toEqual('14.968125')
+  })
 })

--- a/lib/kinesis.js
+++ b/lib/kinesis.js
@@ -24,6 +24,8 @@ exports.format = function ({
   bytes,
   seconds,
   percent,
+  durations,
+  types,
   isDuplicate,
   cause,
 }) {
@@ -41,6 +43,8 @@ exports.format = function ({
     rec.bytes = bytes
     rec.seconds = round(seconds, 2)
     rec.percent = round(percent, 4)
+    rec.durations = durations
+    rec.types = types
   } else {
     rec.type = 'segmentbytes'
     rec.segment = segment

--- a/lib/kinesis.js
+++ b/lib/kinesis.js
@@ -21,11 +21,9 @@ exports.format = function ({
   le,
   digest,
   segment,
-  segmentPosition,
   bytes,
   seconds,
   percent,
-  percentAds,
   isDuplicate,
   cause,
 }) {
@@ -43,12 +41,9 @@ exports.format = function ({
     rec.bytes = bytes
     rec.seconds = round(seconds, 2)
     rec.percent = round(percent, 4)
-    rec.percentAds = round(percentAds, 4)
   } else {
     rec.type = 'segmentbytes'
     rec.segment = segment
-    rec.segmentPosition = segmentPosition
-    rec.percentAds = round(percentAds, 4)
   }
   return rec
 }

--- a/lib/kinesis.test.js
+++ b/lib/kinesis.test.js
@@ -7,16 +7,8 @@ describe('kinesis', () => {
   let redis, overall, segment
   beforeEach(() => {
     redis = new RedisBackup(process.env.REDIS_URL)
-    overall = {
-      le: '1234',
-      digest: '5678',
-      time: 9,
-      bytes: 10,
-      seconds: 12,
-      percent: 0.4,
-      percentAds: 0.1,
-    }
-    segment = { ...overall, segment: 2, segmentPosition: 1, percentAds: 0.1 }
+    overall = { le: '1234', digest: '5678', time: 9, bytes: 10, seconds: 12, percent: 0.4 }
+    segment = { ...overall, segment: 2 }
     process.env.KINESIS_IMPRESSION_STREAM = 'some-good-stream'
   })
 
@@ -63,7 +55,6 @@ describe('kinesis', () => {
       bytes: 10,
       seconds: 12,
       percent: 0.4,
-      percentAds: 0.1,
     })
   })
 
@@ -71,8 +62,6 @@ describe('kinesis', () => {
     expect(kinesis.format(segment)).toEqual({
       type: 'segmentbytes',
       segment: 2,
-      segmentPosition: 1,
-      percentAds: 0.1,
       listenerEpisode: '1234',
       digest: '5678',
       timestamp: 9,


### PR DESCRIPTION
New plan.

Revert #51, and instead send with _the overall download_ the durations and types of each segment.  Let analytics-ingest sort out what to make of that.